### PR TITLE
Fix for firefox table styling

### DIFF
--- a/app/public/global.css
+++ b/app/public/global.css
@@ -410,6 +410,12 @@ input[type=number] {
 .datatable tr:hover, .datatable tr.active {
   background: var(--grey) !important;
 }
+/* fix for mozilla grey background overflow */
+@-moz-document url-prefix() {
+  .datatable tr:hover, .datatable tr.active {
+    background: var(--white) !important;
+  }
+}  
 .datatable tr.active {
   box-shadow: var(--neu-shadow-inset-low) !important;
 }


### PR DESCRIPTION
No more grey background on `hover` or `active`.