### PR TITLE
add try catch when refreshOldReserves is called

### DIFF
--- a/app/src/scripts/jet.ts
+++ b/app/src/scripts/jet.ts
@@ -216,9 +216,13 @@ export const deposit = async (abbrev: string, lamports: BN)
     return [false, undefined];
   }
 
-  const [ok, txid] = await refreshOldReserves();
-  if (!ok) {
-    return [false, txid]
+  try {
+    const [ok, txid] = await refreshOldReserves();
+    if (!ok) {
+      return [false, txid]
+    }
+  } catch (err) {
+    console.log(err);
   }
 
   let reserve = market.reserves[abbrev];
@@ -384,9 +388,13 @@ export const withdraw = async (abbrev: string, amount: Amount)
     return [false, undefined];
   }
 
-  const [ok, txid] = await refreshOldReserves();
-  if (!ok) {
-    return [false, txid]
+  try {
+    const [ok, txid] = await refreshOldReserves();
+    if (!ok) {
+      return [false, txid]
+    }
+  } catch (err) {
+    console.log(err);
   }
 
   const reserve = market.reserves[abbrev];
@@ -491,9 +499,13 @@ export const borrow = async (abbrev: string, amount: Amount)
     return [false, undefined];
   }
 
-  const [ok, txid] = await refreshOldReserves();
-  if (!ok) {
-    return [false, txid]
+  try {
+    const [ok, txid] = await refreshOldReserves();
+    if (!ok) {
+      return [false, txid]
+    }
+  } catch (err) {
+    console.log(err);
   }
 
   const reserve = market.reserves[abbrev];
@@ -605,9 +617,13 @@ export const repay = async (abbrev: string, lamports: BN)
     return [false, undefined];
   }
 
-  const [ok, txid] = await refreshOldReserves();
-  if (!ok) {
-    return [false, txid]
+  try {
+    const [ok, txid] = await refreshOldReserves();
+    if (!ok) {
+      return [false, txid]
+    }
+  } catch (err) {
+    console.log(err);
   }
 
   const reserve = market.reserves[abbrev];

--- a/app/src/scripts/programUtil.ts
+++ b/app/src/scripts/programUtil.ts
@@ -149,7 +149,7 @@ export const getTokenAccountAndSubscribe = function (
   let subscriptionId = getAccountInfoAndSubscribe(connection, publicKey, (account, context) => {
     if (account != null) {
       if(account.data.length != 165){
-        console.log(account.data.length);
+        console.log('account data length', account.data.length);
       }
       const decoded = parseTokenAccount(account, publicKey);
       const amount = TokenAmount.tokenAccount(decoded.data, decimals);


### PR DESCRIPTION
This is a temporary fix to let trade actions go through. The error "Uncaught (in promise) Error: Number is too big" is still there. 