### PR TITLE
Fix withdrawing sol twice

### DIFF
--- a/app/rollup.config.js
+++ b/app/rollup.config.js
@@ -11,7 +11,6 @@ import builtins from 'rollup-plugin-node-builtins';
 import typescript from '@rollup/plugin-typescript';
 import { sveltePreprocess } from 'svelte-preprocess/dist/autoProcess';
 import replace from '@rollup/plugin-replace';
-import json from "@rollup/plugin-json";
 
 config();
 const development = process.env.DEVELOPMENT === 'true';


### PR DESCRIPTION
Fix withdrawing sol twice in same session causing an error because an associated token account was closed.

Fix import in rollup config.