### PR TITLE
Merge master into mainnet-frontend

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -881,7 +881,6 @@
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz",
       "integrity": "sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==",
-      "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "resolve": "^1.17.0"
@@ -899,7 +898,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -915,8 +913,7 @@
     "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
     },
     "node_modules/@solana/buffer-layout": {
       "version": "3.0.0",
@@ -1031,8 +1028,7 @@
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.24",
@@ -6038,7 +6034,6 @@
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.5.tgz",
       "integrity": "sha512-QL/LvDol/PAGB2O0S7/+q2HpSUNodpw7z6nGn9BfoVCPOZ0r4EALrojFU29Bkoi2Hr2jgTocTejJ5GGWZfOxbQ==",
-      "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "resolve": "^1.17.0"
@@ -6048,7 +6043,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -6058,8 +6052,7 @@
         "estree-walker": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
         }
       }
     },
@@ -6155,8 +6148,7 @@
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/express-serve-static-core": {
       "version": "4.17.24",

--- a/app/public/global.css
+++ b/app/public/global.css
@@ -17,8 +17,8 @@
   --black: #444444;
   --grey: #d8dfec;
 	--white: #e6edf7; /* e4ebf5 */
-	--jet-green: #40a387; /* 53bd9f */
-	--jet-blue: #2994be; /* 32a5d3 */
+	--jet-green: #3d9e83; /* 53bd9f */
+	--jet-blue: #278db6; /* 32a5d3 */
   --success: #44a88c; /* 53bd9f */
   --failure: #ec6a69;
 
@@ -37,10 +37,12 @@
   --neu-shadow-inset-gradient: inset -2px -2px 2.5px #75d3f8, inset 2px 2px 2.5px #28866c;
   --neu-shadow-inset-gradient-low: inset -1.5px -1.5px 2px #75d3f8, inset 1.5px 1.5px 2px #28866c;
 
-  --disabled-opacity: 0.75;
+  --disabled-opacity: 0.8;
 
   --nav-width: 60px;
   --mobile-nav-height: 60px;
+
+  --transition: all 0.1s;
 
   --spacing-xs: 4px;
   --spacing-sm: 8px;
@@ -85,7 +87,7 @@ a, i {
   font-style: normal;
 }
 span {
-  opacity: 0.75;
+  opacity: 0.85;
   font-size: 13px;
   text-align: center;
   max-width: 400px;
@@ -93,8 +95,12 @@ span {
 .info {
   color: var(--black);
   opacity: var(--disabled-opacity);
-  font-size: 8px !important;
+  font-size: 9px !important;
   cursor: pointer;
+  transition: var(--transition);
+}
+.info:hover {
+  opacity: 1;
 }
 *:focus-visible {
   outline: unset;
@@ -293,7 +299,7 @@ input[type=number] {
   font-weight: bold;
   text-transform: uppercase;
   font-size: 9px;
-  opacity: 0.65;
+  opacity: 0.85;
 }
 
 /* Modals */
@@ -304,7 +310,7 @@ input[type=number] {
   top: 0;
   left: var(--nav-width);
   background: var(--white);
-  opacity: 0.92;
+  opacity: 0.90;
   text-align: center;
 }
 .modal {
@@ -313,7 +319,7 @@ input[type=number] {
   left: calc(50% + var(--nav-width)/2);
   transform: translate(-50%, -50%);
   min-width: 300px;
-  max-width: 550px;
+  max-width: 700px;
   box-shadow: var(--neu-shadow);
   background: var(--white);
   border-radius: var(--border-radius);
@@ -481,7 +487,7 @@ input[type=number] {
   left: 24px !important;
   padding-left: 1px !important;
   font-size: 15px !important;
-  opacity: 0.8 !important;
+  opacity: 0.85 !important;
 }
 .datatable .dt-asset span, .datatable .dt-asset img {
   opacity: 1 !important;
@@ -517,7 +523,8 @@ input[type=number] {
   opacity: 1 !important;
 }
 .datatable .faucet {
-  opacity: 0.5 !important;
+  opacity: var(--disabled-opacity) !important;
+  transiation: var(--transition) !important;
 }
 .datatable .faucet:hover {
   opacity: 1 !important;
@@ -535,9 +542,10 @@ input[type=number] {
   font-weight: 500 !important;
 }
 .transaction-logs .datatable {
+  padding: unset !important;
   box-shadow: unset !important;
 }
-.transaction-logs .datatable td{
+.transaction-logs .datatable td {
   min-width: 125px !important;
 }
 .transaction-logs .datatable td:last-of-type {
@@ -637,7 +645,7 @@ input[type=number] {
   .datatable td {
     font-size: 11px !important;
   }
-  .transaction-logs .datatable td{
+  .transaction-logs .datatable td {
     min-width: 70px !important;
   }
 }

--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -10,6 +10,7 @@
   import Settings from './views/Settings.svelte';
   import Loader from './components/Loader.svelte';
   import Copilot from './components/Copilot.svelte';
+  import Notifications from './components/Notifications.svelte';
 
   let launchUI: boolean = false;
   onMount(async () => {
@@ -43,4 +44,5 @@
     <Loader fullscreen />
   {/if}
   <Copilot />
+  <Notifications />
 </Router>

--- a/app/src/components/Button.svelte
+++ b/app/src/components/Button.svelte
@@ -9,7 +9,7 @@
 
 <button class="bicyclette" class:secondary class:small class:disabled class:error
   title={text}
-  on:click={() => !disabled ? onClick() : null}>
+  on:click={() => {if(!disabled) onClick()}}>
   {text}
 </button>
 

--- a/app/src/components/ConnectWallet.svelte
+++ b/app/src/components/ConnectWallet.svelte
@@ -36,7 +36,7 @@
 
 <div class="modal-bg"
   transition:fade={{duration: closeable ? 50 : 0}}
-  on:click={() => closeable ? closeModal() : null}>
+  on:click={() => {if (closeable) closeModal()}}>
 </div>
 <div class="modal flex align-center justify-center column"
   in:fly={{y: closeable ? 50 : 0, duration: closeable ? 500 : 0}}
@@ -111,6 +111,5 @@
   p {
     font-size: 14px;
     text-align: center;
-    opacity: 0.8;
   }
 </style>

--- a/app/src/components/Copilot.svelte
+++ b/app/src/components/Copilot.svelte
@@ -155,6 +155,8 @@
   }
   span {
     max-width: 400px;
+    line-height: 16px;
+    opacity: 1;
   }
 
   @media screen and (max-width: 1100px) {

--- a/app/src/components/Logo.svelte
+++ b/app/src/components/Logo.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div class="logo flex align-center justify-center">
-  <img src="img/jet/jet_logomark_gradient.png" alt="Jet Logomark" 
+  <img src="img/jet/jet_logomark_gradient.png" alt="Jet Logomark"
     style={`width: ${width}px; ${logoMark ? 'height: auto; opacity: 1' : 'height: 0px; opacity: 0; position: absolute;'}`} 
   />
   <img src="img/jet/jet_logo_gradient.png" alt="Jext Logo"

--- a/app/src/components/Nav.svelte
+++ b/app/src/components/Nav.svelte
@@ -39,7 +39,8 @@
   class:expanded
   style={launchUI ? 'opacity: 1;' : 'opacity: 0;'}>
 	<div class="top flex align-center column">
-    <div class="nav-logo-container flex align-center justify-center">
+    <div class="nav-logo-container flex align-center justify-center"
+      on:click={() => window.open('https://jetprotocol.io/', '_blank')}>
       <Logo width={!expanded ? 50 : 100} logoMark={!expanded} />
     </div>
     <NavLink active={$location.pathname === '/'} 
@@ -77,7 +78,7 @@
           />
           {#if expanded}
             <div class="flex align-start justify-start column">
-              <span class="bicyclette text-gradient">
+              <span class="bicyclette-bold text-gradient">
                 {dictionary[$PREFERRED_LANGUAGE].copilot.name.toUpperCase()}
               </span>
             </div>
@@ -217,6 +218,7 @@
   }
   .nav-logo-container {
     height: 80px;
+    cursor: pointer;
   }
   .expanded .wallet, .expanded .copilot {
     width: 100px;

--- a/app/src/components/Notifications.svelte
+++ b/app/src/components/Notifications.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { fade, fly } from 'svelte/transition';
+  import { navigate } from 'svelte-navigator';
+  import { NOTIFICATIONS } from '../store';
+  import { clearNotification } from '../scripts/utils';
+</script>
+
+{#if $NOTIFICATIONS.length}
+  <div class="notifications flex align-center justify-center column">
+    {#each $NOTIFICATIONS as n, i}
+      <div class="notification flex align-center justify-center"
+        class:success={n.success}
+        in:fly={{y: 50, duration: 500}}
+        out:fade={{duration: 50}}>
+        <div class="copilot-img flex align-center justify-center"
+          on:click={() => {if (n.success) navigate("/transactions")}}>
+          <img src="img/copilot/copilot.png" 
+            alt="Copilot Icon"
+          />
+        </div>
+        <p on:click={() => {if (n.success) navigate("/transactions")}}>
+          {@html n.text}
+        </p>
+        <i class="jet-icons close"
+          on:click={() => clearNotification(i)}>
+          ✕
+        </i>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .notifications {
+    position: fixed;
+    bottom: var(--spacing-sm);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    z-index: 9999;
+  }
+  .notification {
+    position: relative;
+    background: var(--failure);
+    margin-top: var(--spacing-md);
+    border-radius: var(--btn-radius);
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2), 0 3px 6px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+  }
+  .notification.success {
+    background: var(--success);
+  }
+  .copilot-img {
+    width: 25px;
+    height: 25px;
+    background: var(--white);
+    box-shadow: var(--neu-shadow-inset-low);
+    margin: var(--spacing-sm);
+    padding: var(--spacing-xs);
+    border-radius: 50px;
+  }
+  .close {
+    font-size: 14px;
+    padding: var(--spacing-sm);
+    color: var(--white);
+    cursor: pointer;
+  }
+  p {
+    font-size: 14px;
+    max-width: 300px;
+    padding: var(--spacing-sm);
+    color: var(--white);
+    opacity: 1;
+  }
+  img {
+    width: 100%;
+  }
+</style>

--- a/app/src/components/Toggle.svelte
+++ b/app/src/components/Toggle.svelte
@@ -74,7 +74,7 @@
   .crypto, .usd {
     width: 50%;
     height: 100%;
-    padding: var(--spacing-xs) 0;
+    padding: 5px 0 4px 0;
   }
   .crypto {
     border-top-left-radius: var(--round-radius);
@@ -91,7 +91,7 @@
   .crypto i, .usd i {
     color: var(--black);
     margin: unset;
-    font-size: 14px;
+    font-size: 16px;
     opacity: var(--disabled-opacity);
   }
   .crypto i {

--- a/app/src/models/JetTypes.ts
+++ b/app/src/models/JetTypes.ts
@@ -1,4 +1,4 @@
-import type { AccountInfo, PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
+import type { AccountInfo, PublicKey, TransactionInstruction } from '@solana/web3.js';
 import type BN from 'bn.js';
 import type WalletAdapter from '../scripts/walletAdapter';
 import type { TokenAmount } from '../scripts/utils';
@@ -431,4 +431,10 @@ export interface ReserveMetadata {
     dexSwapTokens: number,
     dexOpenOrders: number,
   },
+};
+
+// Notifications
+export interface Notification {
+  success: boolean,
+  text: string
 };

--- a/app/src/scripts/languages/Jet_UI_EN.json
+++ b/app/src/scripts/languages/Jet_UI_EN.json
@@ -9,7 +9,6 @@
     },
     "nav": {
         "cockpit": "Cockpit",
-        "transactions": "Flight Logs",
         "settings": "Settings",
         "collapse": "Collapse",
         "getCopilotSuggestion": "Get Copilot Suggestion",
@@ -68,13 +67,6 @@
         "rejectTrade": "This trade would lower your collateralization ratio to {{NEW-C-RATIO}}%, which would be below our minimum ratio of {{JET MIN C-RATIO}}. Would you still like to borrow?",
         "insufficientLamports": "You are depositing all your SOL leaving you no lamports for transaction fees! Please try again with a slightly lower input amount.",
         "stillUndercollateralized": "Your new C-ratio of {{NEW-C-RATIO}}% is still under Jet's minimum marketplace collateralization ratio of {{JET MIN C-RATIO}}%. Please consider repaying more to avoid liquidation."
-    },
-    "transactions": {
-      "title": "Flight Logs",
-      "date": "Date",
-      "signature": "Signature",
-      "tradeAction": "Transaction",
-      "tradeAmount": "Amount"
     },
     "settings": {
         "title": "Settings",
@@ -140,18 +132,18 @@
         "alert": {
             "failed": "Mayday!",
             "success": "Success!",
-            "airdropSuccess": "We have Airdropped you {{UI AMOUNT}} {{RESERVE ABBREV}}. Please refresh the app to see your new balance.",
+            "airdropSuccess": "We have Airdropped you {{UI AMOUNT}} {{RESERVE ABBREV}}.",
             "refresh": "Refresh",
             "originationFee": "There is a fee of {{ORIGINATION FEE}}% attached to this loan.",
             "headsup": "Heads up!"
         }
     },
     "transactions": {
-        "title": "Flight Logs",
-        "date": "Date",
-        "signature": "Signature",
-        "tradeAction": "Transaction",
-        "tradeAmount": "Amount",
-        "noTrades": "You have no logged transactions with Jet."
+      "title": "Flight Logs",
+      "date": "Date",
+      "signature": "Signature",
+      "tradeAction": "Transaction",
+      "tradeAmount": "Amount",
+      "noTrades": "You have no logged transactions with Jet."
     }
 }

--- a/app/src/scripts/languages/Jet_UI_ZH.json
+++ b/app/src/scripts/languages/Jet_UI_ZH.json
@@ -139,11 +139,11 @@
         }
     },
     "transactions": {
-        "title": "飞行日志",
-        "date": "日期",
-        "signature": "签章",
-        "tradeAction": "交易",
-        "tradeAmount": "金额",
-        "noTrades": "您在 Jet 没有交易的记录。"
+      "title": "飞行日志",
+      "date": "日期",
+      "signature": "签章",
+      "tradeAction": "交易",
+      "tradeAmount": "金额",
+      "noTrades": "您在 Jet 没有交易的记录。"
     }
 }

--- a/app/src/scripts/localization.ts
+++ b/app/src/scripts/localization.ts
@@ -11,6 +11,7 @@ import * as Jet_Definitions_RU from './languages/Jet_Definitions_RU.json';
 import * as Jet_UI_TR from './languages/Jet_UI_TR.json';
 import * as Jet_Definitions_TR from './languages/Jet_Definitions_TR.json';
 
+// Check to see if user's locale is special case of Crimea
 const isCrimea = (locale: Locale): boolean => {
   const postalCode: string = locale?.postal.toString().substring(0, 2);
   if (postalCode === "95" || postalCode === "96" || postalCode === "97" || postalCode === "98") {

--- a/app/src/scripts/programUtil.ts
+++ b/app/src/scripts/programUtil.ts
@@ -523,7 +523,7 @@ const interpolate = (x: number, x0: number, x1: number, y0: number, y1: number):
 
 /** Continuous Compounding Rate 
 */
-export const getCcRate = (reserveConfig: ReserveConfigStruct, outstandingDebt: number, vaultTotal: number, utilRate: number): number => {
+export const getCcRate = (reserveConfig: ReserveConfigStruct, utilRate: number): number => {
   const basisPointFactor = 10000;
   let util1 = reserveConfig.utilizationRate1 / basisPointFactor;
   let util2 = reserveConfig.utilizationRate2 / basisPointFactor;

--- a/app/src/scripts/utils.ts
+++ b/app/src/scripts/utils.ts
@@ -1,14 +1,18 @@
 import { BN } from '@project-serum/anchor';
 import type { AccountInfo as TokenAccountInfo, MintInfo, u64 } from '@solana/spl-token';
-import type { Market, AssetStore, Obligation } from '../models/JetTypes';
-import { MARKET, ASSETS, DARK_THEME, WALLET, WALLET_INIT } from '../store';
+import type { Market, AssetStore, Obligation, Notification } from '../models/JetTypes';
+import { MARKET, ASSETS, DARK_THEME, WALLET, WALLET_INIT, NOTIFICATIONS } from '../store';
 
 let wallet: any;
 let market: Market | null;
 let assets: AssetStore | null;
+let notifications: Notification[];
 WALLET.subscribe(data => wallet = data);
 MARKET.subscribe(data => market = data);
 ASSETS.subscribe(data => assets = data);
+NOTIFICATIONS.subscribe(data => notifications = data);
+
+const NOTIFICATION_TIMEOUT = 4000;
 
 // If user's browser has dark theme preference, set app to dark theme right on init
 export const initDarkTheme = () => {
@@ -30,6 +34,8 @@ export const setDark = (darkTheme: boolean): void => {
     document.documentElement.style.setProperty('--dark-shadow', 'rgba(54, 54, 54, 0.85)');
     document.documentElement.style.setProperty('--input-color', 'rgba(255, 255, 255, 0.7)');
   } else {
+    document.documentElement.style.setProperty('--jet-green', '#3d9e83');
+    document.documentElement.style.setProperty('--jet-blue', '#278db6');
     document.documentElement.style.setProperty('--black', '#1a495e');
     document.documentElement.style.setProperty('--grey', '#dee4ec');
     document.documentElement.style.setProperty('--white', '#e6edf7');
@@ -95,8 +101,7 @@ export const totalAbbrev = (total: number, price?: number, native?: boolean, dig
 
 // Shorten a pubkey with ellipses
 export const shortenPubkey = (pubkey: string, halfLength: number): string => {
-  return `${pubkey.substring(0, halfLength)}...
-  ${pubkey.substring(pubkey.length - halfLength)}`;
+  return `${pubkey.substring(0, halfLength)}...${pubkey.substring(pubkey.length - halfLength)}`;
 };
 
 // Manual timeout promise to pause program execution
@@ -104,6 +109,24 @@ export const timeout = (ms: number): Promise<boolean> => {
   return new Promise((res) => {
     setTimeout(() => res(true), ms);
   });
+};
+
+// Notification store
+export const addNotification = (notification: Notification) => {
+  const notifs = notifications;
+  notifs.push(notification);
+  const index = notifs.indexOf(notification);
+  NOTIFICATIONS.set(notifs);
+  setTimeout(() => {
+    if (notifications[index] && notifications[index].text === notification.text) {
+      clearNotification(index);
+    }
+  }, NOTIFICATION_TIMEOUT);
+};
+export const clearNotification = (index: number): void => {
+  const notifs = notifications;
+  notifs.splice(index, 1);
+  NOTIFICATIONS.set(notifs);
 };
 
 // Calculate total value of deposits and borrowings, as well as c-ratio

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -1,5 +1,5 @@
 import type * as anchor from '@project-serum/anchor';
-import type { Market, Reserve, AssetStore, Copilot, Locale, CustomProgramError, IdlMetadata, TransactionLog } from './models/JetTypes';
+import type { Market, Reserve, AssetStore, Copilot, Locale, TransactionLog, Notification, CustomProgramError, IdlMetadata } from './models/JetTypes';
 import { writable } from 'svelte/store';
 
 // Writable value stores
@@ -18,9 +18,10 @@ export const DARK_THEME = writable<boolean> (false);
 export const PREFERRED_NODE = writable<string | null> (null);
 export const PING = writable<number> (0);
 export const WALLET_INIT = writable<boolean> (false);
-export const CUSTOM_PROGRAM_ERRORS = writable<CustomProgramError[]>([])
-export const ANCHOR_WEB3_CONNECTION = writable<anchor.web3.Connection>(undefined);
-export const ANCHOR_CODER = writable<anchor.Coder>(undefined);
-export const IDL_METADATA = writable<IdlMetadata>(undefined);
 export const LIQUIDATION_WARNED = writable<boolean> (false);
 export const INIT_FAILED = writable<{ geobanned: boolean } | null> (null);
+export const NOTIFICATIONS = writable<Notification[]> ([]);
+export const CUSTOM_PROGRAM_ERRORS = writable<CustomProgramError[]> ([]);
+export const ANCHOR_WEB3_CONNECTION = writable<anchor.web3.Connection> (undefined);
+export const ANCHOR_CODER = writable<anchor.Coder> (undefined);
+export const IDL_METADATA = writable<IdlMetadata> (undefined);

--- a/app/src/views/Cockpit.svelte
+++ b/app/src/views/Cockpit.svelte
@@ -7,10 +7,9 @@
   import type { Reserve, Obligation } from '../models/JetTypes';
   import { TRADE_ACTION, MARKET, ASSETS, CURRENT_RESERVE, NATIVE, COPILOT, PREFERRED_LANGUAGE, WALLET_INIT, INIT_FAILED, LIQUIDATION_WARNED } from '../store';
   import { inDevelopment, airdrop, deposit, withdraw, borrow, repay, getTransactionLogs } from '../scripts/jet';
-  import { currencyFormatter, totalAbbrev, getObligationData, TokenAmount, Amount } from '../scripts/utils';
+  import { currencyFormatter, totalAbbrev, addNotification, getObligationData, TokenAmount, Amount } from '../scripts/utils';
   import { generateCopilotSuggestion } from '../scripts/copilot';
   import { dictionary, definitions } from '../scripts/localization'; 
-  import { explorerUrl } from '../scripts/programUtil';
   import Loader from '../components/Loader.svelte';
   import ConnectWallet from '../components/ConnectWallet.svelte';
   import ReserveDetail from '../components/ReserveDetail.svelte';
@@ -36,7 +35,6 @@
   let disabledMessage: string = '';
   let reserveDetail: Reserve | null = null;
   let sendingTrade: boolean = false;
-  let showAirdrop: boolean = inDevelopment || window.location.hostname.indexOf('devnet') !== -1;
 
   // Datatable settings
   let tableData: Reserve[] = [];
@@ -119,7 +117,7 @@
       } else {
         disabledMessage = disabledMessage = dictionary[$PREFERRED_LANGUAGE].cockpit.belowMinCRatio;
       }
-    } else if ($TRADE_ACTION === 'borrow' && (noDeposits || belowMinCRatio || assetsAreCurrentDeposit[$CURRENT_RESERVE.abbrev] || !$CURRENT_RESERVE.availableLiquidity.uiAmountFloat)) {
+    } else if ($TRADE_ACTION === 'borrow' && (noDeposits || belowMinCRatio || assetsAreCurrentDeposit[$CURRENT_RESERVE.abbrev] || !$CURRENT_RESERVE.availableLiquidity?.uiAmountFloat)) {
       disabledInput = true;
       if (noDeposits) {
         disabledMessage = disabledMessage = dictionary[$PREFERRED_LANGUAGE].cockpit.noDepositsForBorrow;
@@ -161,32 +159,37 @@
   // Adjust user input and calculate updated c-ratio if 
   // they were to submit current trade
   const adjustCollateralizationRatio = (): void => {
-    if (!$CURRENT_RESERVE || !$ASSETS) {
+    if (!$CURRENT_RESERVE || !$ASSETS || inputAmount === null) {
       return;
     }
 
+    // If input is negative, reset to zero
+    if (inputAmount < 0) {
+      inputAmount = 0;
+    }
+
     if ($TRADE_ACTION === 'deposit') {
-      adjustedRatio = (obligation.depositedValue + ((inputAmount ?? 0) * $CURRENT_RESERVE.price)) / (
+      adjustedRatio = (obligation.depositedValue + inputAmount * $CURRENT_RESERVE.price) / (
           obligation.borrowedValue > 0
             ? obligation.borrowedValue
               : 1
         );
     } else if ($TRADE_ACTION === 'withdraw') {
-      adjustedRatio = (obligation.depositedValue - ((inputAmount ?? 0) * $CURRENT_RESERVE.price)) / (
+      adjustedRatio = (obligation.depositedValue - inputAmount * $CURRENT_RESERVE.price) / (
           obligation.borrowedValue > 0 
             ? obligation.borrowedValue
               : 1
         );
     } else if ($TRADE_ACTION === 'borrow') {
       adjustedRatio = obligation.depositedValue / (
-          (obligation.borrowedValue + ((inputAmount ?? 0) * $CURRENT_RESERVE.price)) > 0
+          (obligation.borrowedValue + inputAmount * $CURRENT_RESERVE.price) > 0
             ? (obligation.borrowedValue + ((inputAmount ?? 0) * $CURRENT_RESERVE.price))
               : 1
         );
     } else if ($TRADE_ACTION === 'repay') {
       adjustedRatio = obligation.depositedValue / (
-          (obligation.borrowedValue - ((inputAmount ?? 0) * $CURRENT_RESERVE.price)) > 0 
-            ? (obligation.borrowedValue - ((inputAmount ?? 0) * $CURRENT_RESERVE.price))
+          (obligation.borrowedValue - inputAmount * $CURRENT_RESERVE.price)
+            ? (obligation.borrowedValue - inputAmount * $CURRENT_RESERVE.price)
              : 1
       );
     }
@@ -198,14 +201,14 @@
     tableData = [];
     for (let r in $MARKET.reserves) {
       // Market data
-      marketTVL += $MARKET.reserves[r].marketSize.muln($MARKET.reserves[r].price).uiAmountFloat;
+      marketTVL += $MARKET.reserves[r].marketSize.muln($MARKET.reserves[r].price)?.uiAmountFloat;
       if ($MARKET.reserves[r]) {
         tableData.push($MARKET.reserves[r]);
       }
 
       // Position balances
-      collateralBalances[r] = $ASSETS?.tokens[r]?.collateralBalance.uiAmountFloat ?? 0;
-      loanBalances[r] = $ASSETS?.tokens[r]?.loanBalance.uiAmountFloat ?? 0;
+      collateralBalances[r] = $ASSETS?.tokens[r]?.collateralBalance?.uiAmountFloat ?? 0;
+      loanBalances[r] = $ASSETS?.tokens[r]?.loanBalance?.uiAmountFloat ?? 0;
 
       // Deposit data
      if ($ASSETS) {
@@ -229,8 +232,8 @@
       assetsAreCurrentDeposit[r] = collateralBalances[r] > 0;
       assetsAreCurrentBorrow[r] = loanBalances[r] > 0;
       maxBorrowAmounts[r] = ((obligation.depositedValue / $MARKET.minColRatio) - obligation.borrowedValue) / $MARKET.reserves[r].price;
-      if (maxBorrowAmounts[r] > $MARKET.reserves[r].availableLiquidity.uiAmountFloat) {
-        maxBorrowAmounts[r] = $MARKET.reserves[r].availableLiquidity.uiAmountFloat;
+      if (maxBorrowAmounts[r] > $MARKET.reserves[r].availableLiquidity?.uiAmountFloat) {
+        maxBorrowAmounts[r] = $MARKET.reserves[r].availableLiquidity?.uiAmountFloat;
       }
     };
 
@@ -248,8 +251,12 @@
 
   // Check scenario and submit trade
   const checkSubmit = () => {
+    if (disabledInput) {
+      return;
+    }
+
     // If depositing all SOL, inform user about insufficient lamports and reject 
-    if ($CURRENT_RESERVE?.abbrev === 'SOL' && inputAmount 
+    if ($CURRENT_RESERVE?.abbrev === 'SOL' && inputAmount && $TRADE_ACTION === 'deposit'
       && (walletBalances[$CURRENT_RESERVE.abbrev]?.uiAmountFloat - 0.02) <= inputAmount) {
       COPILOT.set({
         suggestion: {
@@ -258,33 +265,35 @@
         }
       });
     // If trade would result in c-ratio below min ratio, inform user and reject
-    } else if ((obligation?.borrowedValue || $TRADE_ACTION === 'borrow') && adjustedRatio < $MARKET.minColRatio) {
+    } else if ((obligation?.borrowedValue || $TRADE_ACTION === 'borrow') 
+      && adjustedRatio < $MARKET.minColRatio) {
       if (adjustedRatio < obligation?.colRatio) {
         COPILOT.set({
-        suggestion: {
-        good: false,
-        detail: dictionary[$PREFERRED_LANGUAGE].cockpit.rejectTrade
-          .replaceAll('{{NEW-C-RATIO}}', currencyFormatter(adjustedRatio * 100, false, 1))
-          .replaceAll('{{JET MIN C-RATIO}}', $MARKET.minColRatio * 100)
-        }
-      });
-    } else {
-      // If this trade still results in undercollateralization, inform user
-      COPILOT.set({
-        suggestion: {
+          suggestion: {
           good: false,
-          detail: dictionary[$PREFERRED_LANGUAGE].cockpit.stillUndercollateralized
+          detail: dictionary[$PREFERRED_LANGUAGE].cockpit.rejectTrade
             .replaceAll('{{NEW-C-RATIO}}', currencyFormatter(adjustedRatio * 100, false, 1))
-            .replaceAll('{{JET MIN C-RATIO}}', $MARKET.minColRatio * 100),
-          action: {
-            text: dictionary[$PREFERRED_LANGUAGE].cockpit.confirm,
-            onClick: () => submitTrade()
+            .replaceAll('{{JET MIN C-RATIO}}', $MARKET.minColRatio * 100)
           }
-        }
-      });
-    }
+        });
+      } else {
+        // If this trade still results in undercollateralization, inform user
+        COPILOT.set({
+          suggestion: {
+            good: false,
+            detail: dictionary[$PREFERRED_LANGUAGE].cockpit.stillUndercollateralized
+              .replaceAll('{{NEW-C-RATIO}}', currencyFormatter(adjustedRatio * 100, false, 1))
+              .replaceAll('{{JET MIN C-RATIO}}', $MARKET.minColRatio * 100),
+            action: {
+              text: dictionary[$PREFERRED_LANGUAGE].cockpit.confirm,
+              onClick: () => submitTrade()
+            }
+          }
+        });
+      }
     // If trade would result in possible undercollateralization, inform user
-    } else if ((obligation?.borrowedValue || $TRADE_ACTION === 'borrow') && adjustedRatio <= $MARKET.minColRatio + 0.2 && adjustedRatio >= $MARKET.minColRatio) {
+    } else if ((obligation?.borrowedValue || $TRADE_ACTION === 'borrow') && adjustedRatio < obligation?.colRatio
+      && adjustedRatio <= $MARKET.minColRatio + 0.2 && adjustedRatio >= $MARKET.minColRatio) {
         COPILOT.set({
           suggestion: {
             good: false,
@@ -296,14 +305,13 @@
             }
           }
         });
-      } else {
-        submitTrade();
-      }
+    } else {
+      submitTrade();
+    }
   };
 
   // Check user input and submit trade RPC call
   const submitTrade = async (): Promise<void> => {
-    sendingTrade = true;
     if (!$CURRENT_RESERVE || !$ASSETS) {
       return;
     }
@@ -315,12 +323,13 @@
       return;
     }
 
+    sendingTrade = true;
+    let tradeAction = $TRADE_ACTION;
+    let tradeAmount = inputAmount;
     let ok;
     let txid;
-    let tradeAmountString = inputAmount.toString();
-
-    if ($TRADE_ACTION === 'deposit') {
-      if (TokenAmount.tokens(tradeAmountString, walletBalances[$CURRENT_RESERVE.abbrev]?.decimals).amount.gt(walletBalances[$CURRENT_RESERVE.abbrev]?.amount)) {
+    if (tradeAction === 'deposit') {
+      if (TokenAmount.tokens(tradeAmount.toString(), walletBalances[$CURRENT_RESERVE.abbrev]?.decimals).amount.gt(walletBalances[$CURRENT_RESERVE.abbrev]?.amount)) {
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.notEnoughAsset
           .replaceAll('{{ASSET}}', $CURRENT_RESERVE.abbrev);
         inputAmount = null;
@@ -329,10 +338,10 @@
       }
 
       inputError = '';
-      const depositLamports = TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals).amount;
+      const depositLamports = TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount;
       [ok, txid] = await deposit($CURRENT_RESERVE.abbrev, depositLamports);
-    } else if ($TRADE_ACTION === 'withdraw') {
-      if (TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals).amount.gt($CURRENT_RESERVE.availableLiquidity.amount)) {
+    } else if (tradeAction === 'withdraw') {
+      if (TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount.gt($CURRENT_RESERVE.availableLiquidity.amount)) {
         inputAmount = null;
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.noLiquidity;
         sendingTrade = false;
@@ -340,7 +349,7 @@
       }
 
       let collateralBalance = $ASSETS.tokens[$CURRENT_RESERVE.abbrev]?.collateralBalance;
-      if (TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals).amount.gt(collateralBalance.amount)) {
+      if (TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount.gt(collateralBalance.amount)) {
         inputAmount = null;
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.lessFunds;
         sendingTrade = false;
@@ -348,20 +357,20 @@
       }
 
       inputError = '';
-      const withdrawLamports = TokenAmount.tokens(inputAmount.toString(), $CURRENT_RESERVE.decimals).amount;
-      const withdrawAmount = inputAmount === collateralBalances[$CURRENT_RESERVE.abbrev] ?
+      const withdrawLamports = TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount;
+      const withdrawAmount = tradeAmount === collateralBalances[$CURRENT_RESERVE.abbrev] ?
         Amount.depositNotes($ASSETS.tokens[$CURRENT_RESERVE.abbrev].collateralNoteBalance.amount) :
         Amount.tokens(withdrawLamports);
       [ok, txid] = await withdraw($CURRENT_RESERVE.abbrev, withdrawAmount);
-    } else if ($TRADE_ACTION === 'borrow') {
-      if (TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals).amount.gt($CURRENT_RESERVE.availableLiquidity.amount)) {
+    } else if (tradeAction === 'borrow') {
+      if (TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount.gt($CURRENT_RESERVE.availableLiquidity.amount)) {
         inputAmount = null;
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.noLiquidity;
         sendingTrade = false;
         return;
       }
 
-       if ((adjustedRatio && Math.ceil((adjustedRatio * 1000) / 1000) < $MARKET.minColRatio) || inputAmount > maxBorrowAmounts[$CURRENT_RESERVE.abbrev]) {
+       if ((adjustedRatio && Math.ceil((adjustedRatio * 1000) / 1000) < $MARKET.minColRatio) || tradeAmount > maxBorrowAmounts[$CURRENT_RESERVE.abbrev]) {
         inputAmount = null;
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.belowMinCRatio;
         sendingTrade = false;
@@ -369,17 +378,17 @@
       }
 
       inputError = '';
-      const borrowLamports = TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals);
+      const borrowLamports = TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals);
       const borrowAmount = Amount.tokens(borrowLamports.amount);
       [ok, txid] = await borrow($CURRENT_RESERVE.abbrev, borrowAmount);
-    } else if ($TRADE_ACTION === 'repay') {
+    } else if (tradeAction === 'repay') {
       let loanBalance = $ASSETS.tokens[$CURRENT_RESERVE.abbrev].loanBalance;
       if(!loanBalance) {
         sendingTrade = false;
         return;
       }
 
-      if (TokenAmount.tokens(tradeAmountString, $CURRENT_RESERVE.decimals).amount.gt(loanBalance.amount)) {
+      if (TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount.gt(loanBalance.amount)) {
         inputAmount = null;
         inputError = dictionary[$PREFERRED_LANGUAGE].cockpit.oweLess;
         sendingTrade = false;
@@ -387,32 +396,25 @@
       }
 
       inputError = '';
-      const repayLamports = TokenAmount.tokens(inputAmount.toString(), $CURRENT_RESERVE.decimals).amount;
-      const repayAmount = inputAmount === loanBalances[$CURRENT_RESERVE.abbrev]
+      const repayLamports = TokenAmount.tokens(tradeAmount.toString(), $CURRENT_RESERVE.decimals).amount;
+      const repayAmount = tradeAmount === loanBalances[$CURRENT_RESERVE.abbrev]
         ? Amount.loanNotes($ASSETS.tokens[$CURRENT_RESERVE.abbrev].loanNoteBalance.amount)
         : Amount.tokens(repayLamports);
       [ok, txid] = await repay($CURRENT_RESERVE.abbrev, repayAmount);
     }
     
     if (ok && txid) {
-      COPILOT.set({
-        alert: {
-          good: true,
-          header: dictionary[$PREFERRED_LANGUAGE].copilot.alert.success,
-          text: dictionary[$PREFERRED_LANGUAGE].cockpit.txSuccess
-            .replaceAll('{{TRADE ACTION}}', $TRADE_ACTION)
-            .replaceAll('{{AMOUNT AND ASSET}}', `${inputAmount} ${$CURRENT_RESERVE.abbrev}`)
-            .replaceAll('{{EXPLORER LINK}}', explorerUrl(txid))
-        }
+      addNotification({
+        success: true,
+        text: dictionary[$PREFERRED_LANGUAGE].cockpit.txSuccess
+          .replaceAll('{{TRADE ACTION}}', tradeAction)
+          .replaceAll('{{AMOUNT AND ASSET}}', `${tradeAmount} ${$CURRENT_RESERVE.abbrev}`)
       });
       inputAmount = null;
     } else if (!ok && !txid) {
-      COPILOT.set({
-        alert: {
-          good: false,
-          header: dictionary[$PREFERRED_LANGUAGE].copilot.alert.failed,
-          text: dictionary[$PREFERRED_LANGUAGE].cockpit.txFailed
-        }
+      addNotification({
+        success: false,
+        text: dictionary[$PREFERRED_LANGUAGE].cockpit.txFailed
       });
       inputAmount = null;
     }
@@ -600,7 +602,7 @@
             </td>
             <td on:click={() => changeReserve($rows[i])}>
               {totalAbbrev(
-                $rows[i].availableLiquidity.uiAmountFloat,
+                $rows[i].availableLiquidity?.uiAmountFloat,
                 $rows[i].price,
                 $NATIVE,
                 2
@@ -671,7 +673,7 @@
             </td>
             <!--Faucet for testing if in development-->
             <!--Replace with inDevelopment for mainnet-->
-            {#if showAirdrop}
+            {#if inDevelopment}
               <td class="faucet" on:click={() => doAirdrop($rows[i])}>
                 <i class="text-gradient fas fa-parachute-box"
                   title={`Airdrop ${$rows[i].abbrev}`}
@@ -920,7 +922,7 @@
   .trade-action-select {
     width: calc(25% - 1px);
     padding: var(--spacing-sm) 0;
-    background: rgba(0, 0, 0, 0.15);
+    background: rgba(0, 0, 0, 0.25);
     opacity: var(--disabled-opacity);
     cursor: pointer;
   }
@@ -930,9 +932,9 @@
   }
   .trade-action-select p {
     position: relative;
-    font-size: 12px;
+    font-size: 13px;
     letter-spacing: 0.5px;
-    line-height: 10px;
+    line-height: 13px;
     color: var(--white);
   }
   .trade-action-select p::after {


### PR DESCRIPTION
* Mainnet frontend merge (#125)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* Localization update to match transaction logs UI (#115)

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* Update rollup JSON

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Transaction logs (#114)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* fix ai generation, show warning on init

* function to get logs

* add logs of transactions

* add log of transactions

* review changes

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* disable trade switching during tx submit

* Disable trade switching (#122)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* disable trade switching during tx submit

* fix airdrop devnet logic

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Pre-Mainnet Merge

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Mainnet frontend merge (#127)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* Localization update to match transaction logs UI (#115)

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* Update rollup JSON

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Transaction logs (#114)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* fix ai generation, show warning on init

* function to get logs

* add logs of transactions

* add log of transactions

* review changes

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* disable trade switching during tx submit

* Disable trade switching (#122)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* disable trade switching during tx submit

* fix airdrop devnet logic

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Pre-Mainnet Merge

* Mainnet frontend merge (#124)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Added additional check for undercollateralization on repayment

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Sync localization with Poeditor (#97)

* Moved language files into individual JSON

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Sol airdrop cap changed to 1 (#95)

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Fix withdrawing sol twice in same session causing an error because an associated token account was closed. (#110)

Fix import in rollup config.

* Update rollup.config.js

* Update localization files (#104)

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* Update rollup JSON

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* Localization update to match transaction logs UI (#115)

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* Update rollup JSON

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Transaction logs (#114)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* fix ai generation, show warning on init

* function to get logs

* add logs of transactions

* add log of transactions

* review changes

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* disable trade switching during tx submit

* Disable trade switching (#122)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* Added additional check for undercollateralization on repayment

* Init with data (#89)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* init only when data is available

* Update localization.ts (#84)

* small changes to modal transitions

* refactor init

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>

* init failure handling change, allow settings access

* Changed "repay" to "this trade" to account for deposit as well as repayment

* Init failed (#93)

* Frontend catchup (#83)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Update localization.ts (#84)

* Init with data (#88)

* switch .env from PRODUCTION to DEVELOPMENT

* remove google analytics, will add netlify analytics soon

* deposite rate, borrow rate

* fix phantom beta bug

* Switched out APY/APR to rate

Changed JS variable names as well to say Rate instead of APY/APR

* Cyrillic font styling

* Updated Mandarin translations

* Check caps

* Typo

* merging cheryl's changes

* normalize font-size for different languages

* rpc node settings

* rpc node settings

* redesign settings w/Holly

* fix current reserve bug for rpc settings

* add redirects file for netlify

* get rid of 'or c-ratio', utilisation rate definition

* init only when data is available

* small changes to modal transitions

* refactor init

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>

* Wrap up basic spec tests (#85)

* Wrap up tests of basic spec

* init failure handling change, allow settings access

* init failed, rpc handling, settings view

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>

* testing confirmed signatures

* Update Jet_Definitions_EN.json (POEditor.com)

* Update Jet_Definitions_ZH.json (POEditor.com)

* Update Jet_Definitions_KR.json (POEditor.com)

* Update Jet_Definitions_RU.json (POEditor.com)

* Update Jet_Definitions_TR.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* fix ai generation, show warning on init

* Update rollup JSON

* function to get logs

* Update rollup.config.js

Keeping the json plugin, just removing the 2nd json import

* Update rollup.config.js

* add logs of transactions

* add log of transactions

* Update Jet_UI_ZH.json (POEditor.com)

* Update Jet_UI_EN.json (POEditor.com)

* Update Jet_UI_KR.json (POEditor.com)

* Update Jet_UI_RU.json (POEditor.com)

* Update Jet_UI_TR.json (POEditor.com)

* review changes

* disable trade switching during tx submit

* fix airdrop devnet logic

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* Pre-Mainnet Merge

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* fix inDevelopment

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>

* lamport warning only on deposit

* toast notifications

* toast notifications (#131)

* toast notifications

* code review changes

* reload logs after trade

* logs styling

* only render notis if array length

* disabled trade button if input is disabled

* pre-mainnet merges and subtle UI adjustments

Co-authored-by: Rheum rhabarbarum <owlforcherylk@gmail.com>
Co-authored-by: rhubarbgarden <32130807+rhubarbgarden@users.noreply.github.com>
Co-authored-by: eyevz <norman@jetprotocol.io>
Co-authored-by: Tristyn Stimpson <tristynstimpson@gmail.com>