### PR TITLE
make instructions public to enable rust clients

### DIFF
--- a/programs/jet/src/instructions/init_reserve.rs
+++ b/programs/jet/src/instructions/init_reserve.rs
@@ -28,12 +28,12 @@ use crate::utils;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InitReserveBumpSeeds {
-    vault: u8,
-    fee_note_vault: u8,
-    dex_open_orders: u8,
-    dex_swap_tokens: u8,
-    deposit_note_mint: u8,
-    loan_note_mint: u8,
+    pub vault: u8,
+    pub fee_note_vault: u8,
+    pub dex_open_orders: u8,
+    pub dex_swap_tokens: u8,
+    pub deposit_note_mint: u8,
+    pub loan_note_mint: u8,
 }
 
 #[derive(Accounts)]

--- a/programs/jet/src/lib.rs
+++ b/programs/jet/src/lib.rs
@@ -22,7 +22,7 @@ use anchor_lang::prelude::*;
 extern crate static_assertions;
 
 pub mod errors;
-mod instructions;
+pub mod instructions;
 pub mod state;
 pub mod utils;
 

--- a/programs/jet/src/state/reserve.rs
+++ b/programs/jet/src/state/reserve.rs
@@ -104,7 +104,7 @@ pub struct ReserveConfig {
     /// liquidating assetr from this reserve as collateral.
     pub liquidation_dex_trade_max: u64,
 
-    _reserved1: [u8; 24],
+    pub _reserved1: [u8; 24],
 }
 
 #[assert_size(2048)]


### PR DESCRIPTION
This is necessary if we're going to use the multisig cli for init_reserve.