### PR TITLE
Improve serum liquidation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 env:
-  cli-id: anchor-v0.16.dev-75c2085-solana-1.7.8
+  cli-id: anchor-v0.18.dev-7b86aed-solana-1.8.5
 on:
   push:
     branches:
@@ -34,7 +34,7 @@ jobs:
 
       - id: install-solana-tools
         if: steps.cache-cli-deps.outputs.cache-hit != 'true'
-        run: sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
+        run: sh -c "$(curl -sSfL https://release.solana.com/v1.8.5/install)"
 
       - run: echo "PATH=$HOME/.local/share/solana/install/active_release/bin:$PATH" >> $GITHUB_ENV
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -56,95 +56,95 @@ checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "regex",
- "syn 1.0.76",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
  "bs58 0.4.0",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "rustversion",
- "syn 1.0.76",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
  "heck",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-client"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-lang",
  "anyhow",
@@ -158,20 +158,20 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "anchor-lang"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -190,31 +190,31 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anchor-lang",
- "lazy_static",
  "serum_dex",
  "solana-program",
+ "spl-associated-token-account",
  "spl-token",
 ]
 
 [[package]]
 name = "anchor-syn"
-version = "0.16.1"
-source = "git+https://github.com/jet-lab/anchor#fe355ed15960f554dc5c3d27a447ec0b75c7113d"
+version = "0.18.2"
+source = "git+https://github.com/jet-lab/anchor#7b86aed638ca2b86099ca0d839ddb264690c3c26"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
  "heck",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "proc-macro2-diagnostics",
- "quote 1.0.9",
+ "quote 1.0.10",
  "serde",
  "serde_json",
  "sha2",
- "syn 1.0.76",
+ "syn 1.0.81",
  "thiserror",
 ]
 
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
 
 [[package]]
 name = "arrayref"
@@ -270,9 +270,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -394,8 +394,8 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.29",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -404,9 +404,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -415,9 +415,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -434,9 +434,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bv"
@@ -469,9 +469,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e215f8c2f9f79cb53c8335e687ffd07d5bfcb6fe5fc80723762d0be46e7cc54"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -525,10 +525,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.70"
+name = "caps"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "61bf7211aad104ce2769ec05efcdfabf85ee84ac92461d142f22cf8badd0e54c"
+dependencies = [
+ "errno",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -616,6 +627,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,9 +649,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -633,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -648,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -808,9 +834,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -873,6 +899,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlopen"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e80ad39f814a9abe68583cd50a2d45c8a67561c3361ab8da240587dda80937"
+dependencies = [
+ "dlopen_derive",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f236d9e1b1fbd81cea0f9cbdc8dcc7e8ebcd80e6659cd7cb2ad5f6c05946c581"
+dependencies = [
+ "libc",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,9 +929,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "ed25519"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
+checksum = "74e1069e39f1454367eb2de793ed062fac4c35c2934b76a81d90dd9abcd28816"
 dependencies = [
  "serde",
  "signature",
@@ -930,9 +979,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -952,9 +1001,9 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -968,6 +1017,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -986,9 +1056,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -1071,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1086,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1096,15 +1166,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1113,42 +1183,39 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1158,8 +1225,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1219,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -1231,9 +1296,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -1289,9 +1354,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
-version = "1.2.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e07da7e8614133e88b3a93b7352eb3729e3ccd82d5ab661adf23bef1761bf8"
+checksum = "8d6f5e247bc66f3255d755e96d9d43f6b191f4e182072b811d55584ff58c510f"
 dependencies = [
  "cc",
  "libc",
@@ -1352,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1369,9 +1434,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
@@ -1381,9 +1446,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -1445,7 +1510,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.14.1",
+ "console 0.15.0",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -1462,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1550,10 +1615,10 @@ dependencies = [
 name = "jet-proc-macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "static_assertions",
- "syn 1.0.76",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1606,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libloading"
@@ -1755,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1806,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
@@ -1831,9 +1896,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1881,10 +1946,10 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
- "proc-macro-crate 1.0.0",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro-crate 1.1.0",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1895,9 +1960,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -1922,9 +1987,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1942,9 +2007,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
 dependencies = [
  "autocfg",
  "cc",
@@ -1972,9 +2037,9 @@ checksum = "f463857a6eb96c0136b1d56e56c718350cef30412ec065b48294799a088bca68"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2073,15 +2138,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2094,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -2109,9 +2174,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "version_check",
 ]
 
@@ -2121,22 +2186,10 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2149,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -2162,9 +2215,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "version_check",
  "yansi",
 ]
@@ -2195,11 +2248,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
 ]
 
 [[package]]
@@ -2361,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -2596,16 +2649,16 @@ version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -2716,15 +2769,15 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -2755,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89741082d52115e1d866befdf65a9c3197c50734b998f75cfb0a291c3555738"
+checksum = "f75f7002703ee0f9ad9871b6c2f5829bf74e1770f632913b75b8b8d32803be79"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2778,13 +2831,14 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff790bd97dee3be05ec879b176875f0bb0ef0eb62e5e11e6b269a2d7dc8bf10"
+checksum = "221d6c138089d3f55dd7ca96d61240f08011c4bd3965939791939fb612a4b6f3"
 dependencies = [
  "chrono",
  "clap",
  "rpassword",
+ "solana-perf",
  "solana-remote-wallet",
  "solana-sdk",
  "thiserror",
@@ -2795,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb21cb2d46661d9e549293ce2ec4e4afa7205b66562e3768e16f5fe737f420f"
+checksum = "44bffa16600cd86d83f61c9dc95b8df8c952d5b3a771600d9aeb2c7ea9cc3567"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -2809,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f90ee9f77c831426af58c9732902051314bb8f2607473ffd6089a3b008133"
+checksum = "64f99df9f27c5a1c30878dee056edd5906b66555bf1d3c611308d098bd3f2b59"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2842,10 +2896,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-config-program"
-version = "1.7.11"
+name = "solana-compute-budget-program"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6cebea98645f683ed9bf32f7f1e50a643479ab85fc8e6ba1c287a4562f534a4"
+checksum = "a3ce76ec3f5780663c39c2430daae0916cd9fb81688826dd5a634acdce2655c6"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-config-program"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117d2b25301117446b8c9293fb205d9fc6659f1f9f96788764cdfc57870ed9f1"
 dependencies = [
  "bincode",
  "chrono",
@@ -2858,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "solana-crate-features"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f7002fb7a602e75e9f077ba8aab67fff49e24327b958280648e731dab894a6"
+checksum = "a6aabd811ea101694b3b12f5d67d4b94055caebe824267eaa00af95e920fc2e4"
 dependencies = [
  "backtrace",
  "bytes 0.4.12",
@@ -2876,15 +2939,24 @@ dependencies = [
  "ring",
  "serde",
  "syn 0.15.44",
- "syn 1.0.76",
+ "syn 1.0.81",
  "winapi",
 ]
 
 [[package]]
-name = "solana-faucet"
-version = "1.7.11"
+name = "solana-ed25519-program"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ce6d1994d0bdcb0571eeaad0718c540b89b626c24df2bdf6987f80837af4c5"
+checksum = "36d050d95a9d9aa1595ea2afcaf7b5a012f54d4969a6ece6af312f19b3f4dd98"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-faucet"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22c2fb42ce3b3f834ea215a8e5549dcdd76db2f019c8168e1c5a973a31c5803"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2905,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ddfc2b65a555c0e0156c043bce092d473bc4f00daa7ca3c223d97d92d2e807"
+checksum = "bc1012d3d2ab907d942511eefa9e49dc411eeefda964c744ab431e5a4788decd"
 dependencies = [
  "bs58 0.3.1",
  "bv",
@@ -2925,21 +2997,21 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a876aa31298fdee6560c8ee0695ebed313bbdbb6fbbee439ac3b9df8aebfb87c"
+checksum = "2c02e8365ddbab83f2004041032a48e2b9e3b42a3fc44c318aebc96dce6bf920"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "rustc_version 0.2.3",
- "syn 1.0.76",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a07290cc521e529bff0b0afd3aacd1d3904a41f35321ede6d1f3574efa3e94"
+checksum = "298885f4c7c704df17fa48ddf1a1582032e13174bc7e0e8ada57ca62740e8a98"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2948,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ab24cb5a8fb2fdb32e151606e6a954a6d6e4d764102eb96616cb895622d284"
+checksum = "6b17305d54467acb3acc08bdb79f521d971f7affb767cab25675270f7e5d6d3c"
 dependencies = [
  "log",
  "solana-metrics",
@@ -2959,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49cfd9ec1637885f80d0ac33cf71c685fe13bad6de2bfd469e8aa7dc39967a3"
+checksum = "f4aabbe1c893f356d0a000ebe8c0d86ef5b85e76af7ac6cc28c45f20d7371dff"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2973,9 +3045,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be3ee1237d9013cbd11f0d0af69a4473c703b700165e6c39b49cf0c0554d6f9"
+checksum = "3e60f3184e1c5b74c7f24f6a128e91e5d013ac7c5fe899d388e809a73f145bd5"
 dependencies = [
  "bincode",
  "clap",
@@ -2994,17 +3066,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-program"
-version = "1.7.11"
+name = "solana-perf"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ffc60d33a318300682e42d28ff4f1276327f6374cab9591c8620a54be7aec1"
+checksum = "0452214f8b4bf0350dad9a6036b0e60ffe8bd18ab2efd1577d04c75fba145099"
 dependencies = [
+ "bincode",
+ "caps",
+ "curve25519-dalek 2.1.3",
+ "dlopen",
+ "dlopen_derive",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "solana-logger",
+ "solana-metrics",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
+ "solana-vote-program",
+]
+
+[[package]]
+name = "solana-program"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d115ccafc326625e378cd8b4122a2e6a6666ad7907d165e9384a76ecbdb7b745"
+dependencies = [
+ "base64 0.13.0",
  "bincode",
  "blake3",
  "borsh",
  "borsh-derive",
  "bs58 0.3.1",
  "bv",
+ "bytemuck",
  "curve25519-dalek 2.1.3",
  "hex",
  "itertools",
@@ -3030,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0375eae0722ae7303dbc5ce024104155b851017f31d7bc5096a871153540561"
+checksum = "2b2a52fbbc074efabca93cbed5b093fc7ae8a31d749a6287814c1001f7d4cc5e"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -3040,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cfa60250c3f8f1c2de9258d35202021ddf1379a24a5820ec813de392af3d94"
+checksum = "82b91d441ed00427226b08e9990367ecb4c952c70ab827c0250bd233e1ae9540"
 dependencies = [
  "base32",
  "console 0.14.1",
@@ -3061,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58793cb7e9a2996ad3785816f58fddb7e29be245e6c12d0db62d8b4c6f6d17c2"
+checksum = "82c10c2984fd0dca4a4265ca5b99c3833bb813c6688b1b2ed4ace0807bdfd6f1"
 dependencies = [
  "arrayref",
  "bincode",
@@ -3092,7 +3191,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "serde",
  "serde_derive",
+ "solana-compute-budget-program",
  "solana-config-program",
+ "solana-ed25519-program",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -3112,14 +3213,18 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95179bc7d87c5b61c86f3bbbac4e52a5d909432473593d33546e4f20dc582052"
+checksum = "35fd9c39ffa29e3ec09bc4553cf892c48df730694e546eacd378900c6a0b59f2"
 dependencies = [
  "assert_matches",
+ "base64 0.13.0",
  "bincode",
- "bs58 0.3.1",
+ "borsh",
+ "borsh-derive",
+ "bs58 0.4.0",
  "bv",
+ "bytemuck",
  "byteorder",
  "chrono",
  "derivation-path",
@@ -3161,31 +3266,31 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b453dca160617b1676c47e3cfd4361f455dc5bb1c93659ec84b0c5d566b5c039"
+checksum = "91983679137d5a342cc99f56dbb418def7af5712a5edb2636d3637c897962f9b"
 dependencies = [
  "bs58 0.3.1",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "rustversion",
- "syn 1.0.76",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "solana-secp256k1-program"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389178c92126e1e85189414688f93e9be836272bbe6ab03db04c804921eb09bd"
+checksum = "f4f8def349f434902ab4073a7dde49a4f45673004e510c7579c234d3636f6065"
 dependencies = [
  "solana-sdk",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e690a0aed0ff8c854ee79ec9c437756f9c0a24cdb0c1d0e979b60db8b6a4513"
+checksum = "11034c5ad850bf0993c333fde46d17441e5af156644d5aaab59e13d2130a1064"
 dependencies = [
  "bincode",
  "log",
@@ -3205,19 +3310,22 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692b993f3e2ee1d3ffd9eb50e079bc9cc702d6a3a833d0c2c14a46d9268ea750"
+checksum = "fc9d671057460aab1958a2adefe724bf2be02cf0d4b4a3599356d01b65d0e8ba"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
  "bincode",
  "bs58 0.3.1",
  "lazy_static",
+ "log",
  "serde",
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-measure",
+ "solana-metrics",
  "solana-runtime",
  "solana-sdk",
  "solana-vote-program",
@@ -3229,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8d410e68becf2a80a582caa46349dca6959ecf1319fe722a11a33e46af229b"
+checksum = "e30c29cd46a42e0b58360b3d4559e943e86b281073240f978e10d99fb00fe76e"
 dependencies = [
  "log",
  "rustc_version 0.2.3",
@@ -3245,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.7.11"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc0bed4119e725a813a56ace42738ab5bbfbfc36152b169bd957ae38e62543a"
+checksum = "52d4d38344e8c1c383d3a28bf6455d34f0bd48b17f8bf6684b55abf18674a632"
 dependencies = [
  "bincode",
  "log",
@@ -3323,9 +3431,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3334,15 +3442,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3370,24 +3478,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "unicode-xid 0.2.2",
 ]
 
@@ -3463,22 +3571,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3512,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3527,9 +3635,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes 1.1.0",
@@ -3547,13 +3655,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3569,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -3598,9 +3706,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -3668,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -3797,8 +3905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -3811,9 +3917,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -3835,7 +3941,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.10",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3845,9 +3951,9 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3962,22 +4068,22 @@ checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 

--- a/libraries/math/src/number.rs
+++ b/libraries/math/src/number.rs
@@ -138,7 +138,7 @@ impl Number {
         Number(self.0.saturating_mul(n.0))
     }
 
-    fn ten_pow(exponent: u32) -> U192 {
+    pub fn ten_pow(exponent: u32) -> U192 {
         let value: u64 = match exponent {
             16 => 10_000_000_000_000_000,
             15 => 1_000_000_000_000_000,

--- a/libraries/ts/src/market.ts
+++ b/libraries/ts/src/market.ts
@@ -10,12 +10,15 @@ import * as util from "./util";
 const MAX_RESERVES = 32;
 
 const ReserveInfoStruct = BL.struct([
-  util.pubkeyField("reserve"),
+  util.pubkeyField("address"),
   BL.blob(80, "_UNUSED_0_"),
   util.numberField("price"),
   util.numberField("depositNoteExchangeRate"),
   util.numberField("loanNoteExchangeRate"),
-  BL.blob(72, "_UNUSED_1_"),
+  util.numberField("minCollateralRatio"),
+  BL.u16("liquidationBonus"),
+  BL.blob(158, "_UNUSED_1_"),
+  BL.blob(16, "_CACHE_TAIL")
 ]);
 
 const MarketReserveInfoList = BL.seq(ReserveInfoStruct, MAX_RESERVES);

--- a/libraries/ts/src/user.ts
+++ b/libraries/ts/src/user.ts
@@ -524,6 +524,10 @@ export class JetUser implements User {
     this._collateral = [];
 
     for (const reserve of this.market.reserves) {
+      if (reserve.address.toBase58() == PublicKey.default.toBase58()) {
+        continue;
+      }
+
       await this.refreshReserve(reserve);
     }
   }
@@ -542,13 +546,19 @@ export class JetUser implements User {
   ) {
     try {
       const info = await this.conn.getAccountInfo(account.address);
+
+      if (info == null) {
+        return;
+      }
+
       const tokenAccount: TokenAccount = TokenAccountLayout.decode(info.data);
 
       appendTo.push({
-        mint: tokenAccount.mint,
-        amount: tokenAccount.amount,
+        mint: new PublicKey(tokenAccount.mint),
+        amount: new anchor.BN(tokenAccount.amount, undefined, "le"),
       });
     } catch (e) {
+      console.log(`error getting user account: ${e}`);
       // ignore error, which should mean it's an invalid/uninitialized account
     }
   }

--- a/libraries/ts/src/util.ts
+++ b/libraries/ts/src/util.ts
@@ -42,10 +42,34 @@ export class PubkeyField extends BL.Layout {
   }
 }
 
+export class U64Field extends BL.Layout {
+  constructor(property?: string) {
+    super(8, property);
+  }
+
+  decode(b: Uint8Array, offset?: number): BN {
+    const start = offset == undefined ? 0 : offset;
+    const data = b.slice(start, start + this.span);
+
+    return new BN(data);
+  }
+
+  encode(src: BN, b: Uint8Array, offset?: number): number {
+    const start = offset == undefined ? 0 : offset;
+    b.set(src.toArray(), start);
+
+    return this.span;
+  }
+}
+
 export function numberField(property?: string): NumberField {
     return new NumberField(property);
 }
 
 export function pubkeyField(property? :string): PubkeyField {
     return new PubkeyField(property);
+}
+
+export function u64Field(property?: string): U64Field {
+  return new U64Field(property);
 }

--- a/programs/jet/Cargo.toml
+++ b/programs/jet/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor" }
-anchor-spl = { git = "https://github.com/jet-lab/anchor" }
+anchor-spl = { git = "https://github.com/jet-lab/anchor", features = ["dex"] }
 solana-program = "1.7"
 thiserror = "1.0"
 bytemuck = { version = "1.7", features = ["derive"] }

--- a/programs/jet/src/instructions/liquidate_dex.rs
+++ b/programs/jet/src/instructions/liquidate_dex.rs
@@ -77,10 +77,26 @@ struct DexClient<'a, 'info> {
 }
 
 impl<'a, 'info> DexClient<'a, 'info> {
+    fn price_lots(
+        &self,
+        price: Number,
+        quote_expo: i32,
+        coin_expo: i32,
+    ) -> Result<u64, ProgramError> {
+        let quote_decimals = (quote_expo * -1) as u32;
+        let coin_decimals = (coin_expo * -1) as u32;
+        let dex_market = DexMarketState::load(&self.dex_market.market, &dex::ID)?;
+
+        Ok(
+            (price * Number::ten_pow(quote_decimals) * dex_market.coin_lot_size
+                / (Number::ten_pow(coin_decimals) * dex_market.pc_lot_size))
+                .as_u64_rounded(0),
+        )
+    }
+
     /// Buy as much of the base currency as possible with the given amount
     /// of quote tokens.
-    fn _buy(&self, quote_amount: u64) -> ProgramResult {
-        let limit_price = u64::MAX;
+    fn buy(&self, limit_price: u64, quote_amount: u64) -> ProgramResult {
         let max_coin_qty = u64::MAX;
         let max_pc_qty = quote_amount;
 
@@ -88,8 +104,7 @@ impl<'a, 'info> DexClient<'a, 'info> {
     }
 
     /// Sell as much of the given base currency as possible.
-    fn sell(&self, base_amount: u64) -> ProgramResult {
-        let limit_price = 1;
+    fn sell(&self, limit_price: u64, base_amount: u64) -> ProgramResult {
         let max_pc_qty = u64::MAX;
         let max_coin_qty = {
             let dex_market = DexMarketState::load(&self.dex_market.market, &dex::ID)?;
@@ -255,7 +270,7 @@ impl<'info> LiquidateDex<'info> {
         )
     }
 
-    fn transfer_swapped_token_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+    fn _transfer_swapped_token_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
         CpiContext::new(
             self.token_program.clone(),
             Transfer {
@@ -297,14 +312,98 @@ impl<'info> LiquidateDex<'info> {
     }
 }
 
+#[derive(Debug)]
+enum SwapKind {
+    Buy,
+    Sell,
+}
+
+#[derive(Debug)]
 struct SwapPlan {
     /// The total value of collateral that can be sold to bring the
     /// loan back into a healthy position.
-    sellable_value: Number,
+    collateral_sellable_value: Number,
 
     /// The total value that would be repaid to cover the loan position,
     /// which may be less than the total collateral sold due to fees.
     loan_repay_value: Number,
+
+    /// The worst price to accept for the trade
+    limit_price: Number,
+
+    /// The kind of trade that should be executed
+    kind: SwapKind,
+}
+
+struct SwapCalculator<'a> {
+    market: &'a Market,
+    loan_reserve: &'a Reserve,
+    collateral_reserve: &'a Reserve,
+    obligation: &'a Obligation,
+}
+
+impl<'a> SwapCalculator<'a> {
+    /// Calculate the plan for swapping the collateral for debt
+    fn plan(&self) -> Result<SwapPlan, ProgramError> {
+        let clock = Clock::get()?;
+        let min_c_ratio = Number::from_bps(self.loan_reserve.config.min_collateral_ratio);
+        let liquidation_fee = Number::from_bps(self.collateral_reserve.config.liquidation_premium);
+        let slippage = Number::from_bps(self.collateral_reserve.config.liquidation_slippage);
+
+        let collateral_reserve_info = self
+            .market
+            .reserves()
+            .get_cached(self.collateral_reserve.index, clock.slot);
+        let loan_reserve_info = self
+            .market
+            .reserves()
+            .get_cached(self.loan_reserve.index, clock.slot);
+
+        let collateral_value = self
+            .obligation
+            .collateral_value(self.market.reserves(), clock.slot);
+        let loan_value = self
+            .obligation
+            .loan_value(self.market.reserves(), clock.slot);
+
+        let loan_to_value = loan_value / collateral_value;
+        let c_ratio_ltv = min_c_ratio * loan_to_value;
+
+        if c_ratio_ltv <= Number::ONE {
+            // This means the loan is over-collateralized, so we shouldn't allow
+            // any liquidation for it.
+            msg!("c_ratio_ltv < 1 implies this cannot be liquidated");
+            return Err(ErrorCode::ObligationHealthy.into());
+        } else if c_ratio_ltv > min_c_ratio {
+            // This means the loan is underwater, so for now we just disallow
+            // liquidations on underwater loans using the DEX.
+            return Err(ErrorCode::Disallowed.into());
+        }
+
+        let limit_fraction = (c_ratio_ltv - Number::ONE)
+            / (min_c_ratio * (Number::ONE - liquidation_fee) - Number::ONE);
+
+        let collateral_sellable_value = limit_fraction * collateral_value;
+        let loan_repay_value = collateral_sellable_value / (Number::ONE + liquidation_fee);
+        let normal_limit_price =
+            (Number::ONE - slippage) * (collateral_reserve_info.price / loan_reserve_info.price);
+
+        let (kind, limit_price) = if self.loan_reserve.token_mint == self.market.quote_token_mint {
+            (SwapKind::Sell, normal_limit_price)
+        } else if self.collateral_reserve.token_mint == self.market.quote_token_mint {
+            (SwapKind::Buy, Number::ONE / normal_limit_price)
+        } else {
+            msg!("cannot liquidate these pairs");
+            return Err(ErrorCode::Disallowed.into());
+        };
+
+        Ok(SwapPlan {
+            collateral_sellable_value,
+            loan_repay_value,
+            limit_price,
+            kind,
+        })
+    }
 }
 
 /// Calculate the estimates for swap values
@@ -313,56 +412,51 @@ fn calculate_collateral_swap_plan(internal: &LiquidateDex) -> Result<SwapPlan, P
     let collateral_reserve = internal.collateral_reserve.load()?;
     let obligation = internal.obligation.load()?;
     let market = internal.market.load()?;
-    let clock = Clock::get()?;
 
-    let min_c_ratio = Number::from_bps(loan_reserve.config.min_collateral_ratio);
-    let liquidation_fee = Number::from_bps(collateral_reserve.config.liquidation_premium);
-    let slippage = Number::from_bps(collateral_reserve.config.liquidation_slippage);
+    let calculator = SwapCalculator {
+        market: &market,
+        loan_reserve: &loan_reserve,
+        collateral_reserve: &collateral_reserve,
+        obligation: &obligation,
+    };
 
-    let collateral_value = obligation.collateral_value(market.reserves(), clock.slot);
-    let loan_value = obligation.loan_value(market.reserves(), clock.slot);
-
-    let loan_to_value = loan_value / collateral_value;
-    let c_ratio_ltv = min_c_ratio * loan_to_value;
-
-    if c_ratio_ltv <= Number::ONE {
-        // This means the loan is over-collateralized, so we shouldn't allow
-        // any liquidation for it.
-        msg!("c_ratio_ltv < 1 implies this cannot be liquidated");
-        return Err(ErrorCode::ObligationHealthy.into());
-    } else if c_ratio_ltv > min_c_ratio {
-        // This means the loan is underwater, so for now we just disallow
-        // liquidations on underwater loans using the DEX.
-        return Err(ErrorCode::Disallowed.into());
-    }
-
-    let fee_plus_slippage = liquidation_fee + slippage;
-
-    // This bound ensures that the plan will actually improve the c-ratio.
-    assert!(fee_plus_slippage < (min_c_ratio - Number::ONE));
-
-    let loan_repay_value = (min_c_ratio * loan_value - collateral_value)
-        / (min_c_ratio - fee_plus_slippage - Number::ONE);
-    let sellable_value = loan_repay_value * (Number::ONE + fee_plus_slippage);
-
-    Ok(SwapPlan {
-        sellable_value,
-        loan_repay_value,
-    })
+    calculator.plan()
 }
 
-/// Sell the collateral by trading on the DEX
-fn sell_collateral<'info>(
+/// Execute the calculated plan to swap the collateral.
+///
+/// Returns the number of collateral tokens swapped.
+fn execute_plan<'info>(
     internal: &LiquidateDex<'info>,
-    dex_market: &DexMarketAccounts<'info>,
-    collateral_value: Number,
+    source_dex_market: &DexMarketAccounts<'info>,
+    target_dex_market: &DexMarketAccounts<'info>,
+    plan: &SwapPlan,
 ) -> Result<Number, ProgramError> {
     let clock = Clock::get()?;
     let market = internal.market.load()?;
-    let reserve = internal.collateral_reserve.load()?;
-    let reserve_info = market.reserves().get_cached(reserve.index, clock.slot);
+    let collateral_reserve = internal.collateral_reserve.load()?;
+    let loan_reserve = internal.loan_reserve.load()?;
+    let collateral_reserve_info = market
+        .reserves()
+        .get_cached(collateral_reserve.index, clock.slot);
 
-    let dex_client = DexClient {
+    let max_collateral_tokens = plan.collateral_sellable_value / collateral_reserve_info.price;
+    let cur_collateral_tokens = collateral_reserve
+        .amount(token::accessor::amount(&internal.collateral_account)?)
+        * collateral_reserve_info.deposit_note_exchange_rate;
+
+    // Limit the amount of tokens sold to the lesser of either:
+    //  * the total value of the collateral allowed to be sold to cover this debt position
+    //  * the total collateral tokens available to the position being liquidated
+    //  * the hard limit of token amounts to execute in a single trade, as configured in the reserve
+    let reserve_sell_limit = match collateral_reserve.config.liquidation_dex_trade_max {
+        0 => collateral_reserve.amount(std::u64::MAX),
+        n => Number::from(n),
+    };
+    let cur_sellable_tokens = std::cmp::min(max_collateral_tokens, cur_collateral_tokens);
+    let max_tradable_tokens = std::cmp::min(cur_sellable_tokens, reserve_sell_limit);
+
+    let get_dex_client = |dex_market, coin_wallet, pc_wallet| DexClient {
         market: &market,
         market_authority: &internal.market_authority,
         dex_program: &internal.dex_program,
@@ -371,58 +465,55 @@ fn sell_collateral<'info>(
         token_program: &internal.token_program,
         rent: &internal.rent,
 
-        coin_wallet: &internal.collateral_reserve_vault,
-        pc_wallet: &internal.dex_swap_tokens,
+        coin_wallet,
+        pc_wallet,
     };
 
-    let max_collateral_tokens = collateral_value / reserve_info.price;
-    let cur_collateral_tokens = reserve
-        .amount(token::accessor::amount(&internal.collateral_account)?)
-        * reserve_info.deposit_note_exchange_rate;
+    match plan.kind {
+        SwapKind::Sell => {
+            // Sell the collateral on the DEX
+            let dex_client = get_dex_client(
+                source_dex_market,
+                &internal.collateral_reserve_vault,
+                &internal.loan_reserve_vault,
+            );
+            let limit_price = dex_client.price_lots(
+                plan.limit_price,
+                loan_reserve.exponent,
+                collateral_reserve.exponent,
+            )?;
 
-    // Limit the amount of tokens sold to the lesser of either:
-    //  * the total value of the collateral allowed to be sold to cover this debt position
-    //  * the total collateral tokens available to the position being liquidated
-    //  * the hard limit of token amounts to execute in a single trade, as configured in the reserve
-    let reserve_sell_limit = match reserve.config.liquidation_dex_trade_max {
-        0 => reserve.amount(std::u64::MAX),
-        n => reserve.amount(n),
-    };
-    let tokens_to_sell = std::cmp::min(max_collateral_tokens, cur_collateral_tokens);
-    let tokens_to_sell = std::cmp::min(tokens_to_sell, reserve_sell_limit);
+            dex_client.sell(
+                limit_price,
+                max_tradable_tokens.as_u64(collateral_reserve.exponent),
+            )?;
+            dex_client.settle()?;
 
-    dex_client.sell(tokens_to_sell.as_u64(reserve.exponent))?;
-    dex_client.settle()?;
+            Ok(max_tradable_tokens)
+        }
 
-    Ok(tokens_to_sell)
-}
+        SwapKind::Buy => {
+            // Use the collateral to buy the debt asset on the DEX
+            let dex_client = get_dex_client(
+                target_dex_market,
+                &internal.loan_reserve_vault,
+                &internal.collateral_reserve_vault,
+            );
+            let limit_price = dex_client.price_lots(
+                plan.limit_price,
+                collateral_reserve.exponent,
+                loan_reserve.exponent,
+            )?;
 
-/// Buy back the loaned asset by trading on the DEX
-fn buy_debt<'info>(
-    internal: &LiquidateDex<'info>,
-    _dex_market: &DexMarketAccounts<'info>,
-) -> Result<(), ProgramError> {
-    let market = internal.market.load()?;
-    let reserve = internal.loan_reserve.load()?;
+            dex_client.buy(
+                limit_price,
+                max_tradable_tokens.as_u64(collateral_reserve.exponent),
+            )?;
+            dex_client.settle()?;
 
-    let quote_tokens = token::accessor::amount(&internal.dex_swap_tokens)?;
-
-    if reserve.token_mint == market.quote_token_mint {
-        // The reserve's assets is the same as the quote token,
-        // so we can just transfer the tokens from the intermediate
-        // account into the reserve.
-        token::transfer(
-            internal
-                .transfer_swapped_token_context()
-                .with_signer(&[&market.authority_seeds()]),
-            quote_tokens,
-        )?;
-    } else {
-        // FIXME: eventually support another swap once tx size permits
-        return Err(ErrorCode::NotSupported.into());
+            Ok(max_tradable_tokens)
+        }
     }
-
-    Ok(())
 }
 
 /// Verify that the amount of tokens we received for selling some collateral is acceptable
@@ -450,6 +541,7 @@ fn verify_proceeds(
     if proceeds_value < min_value {
         // The difference in value is beyond the range of the configured slippage,
         // so reject this result.
+        msg!("proceeds = {}, minimum = {}", proceeds_value, min_value);
         return Err(ErrorCode::LiquidationSwapSlipped.into());
     }
 
@@ -475,7 +567,7 @@ fn update_accounting(
         .reserves()
         .get_cached(collateral_reserve.index, clock.slot);
 
-    let collateral_sell_expected = plan.sellable_value / collateral_info.price;
+    let collateral_sell_expected = plan.collateral_sellable_value / collateral_info.price;
     let collateral_repaid_ratio_actual = collateral_tokens_sold / collateral_sell_expected;
 
     let loan_repaid_value = collateral_repaid_ratio_actual * plan.loan_repay_value;
@@ -539,17 +631,10 @@ fn handler<'info>(
     // Calculate the quote value of collateral that needs to be sold
     let plan = calculate_collateral_swap_plan(internal)?;
 
-    msg!("calculated plan to swap");
-
     // Sell the collateral
-    let collateral_tokens_sold = sell_collateral(internal, source_market, plan.sellable_value)?;
+    let collateral_tokens_sold = execute_plan(internal, source_market, target_market, &plan)?;
 
     msg!("collateral sold");
-
-    // Buy the loaned token
-    buy_debt(internal, target_market)?;
-
-    msg!("debt bought");
 
     let loan_reserve_proceeds =
         token::accessor::amount(&internal.loan_reserve_vault)?.saturating_sub(loan_reserve_tokens);

--- a/programs/jet/src/state/reserve.rs
+++ b/programs/jet/src/state/reserve.rs
@@ -94,9 +94,8 @@ pub struct ReserveConfig {
     /// The fee rate applied as interest owed on new loans
     pub loan_origination_fee: u16,
 
-    /// Sets the slippage amount for trades on the DEX when liquidating
-    /// assets from this reserve as collateral.
-    pub liquidation_slippage: u16,
+    /// unused
+    pub _reserved0: u16,
 
     /// Represented as a percentage of the Price
     /// confidence values above this will not be accepted

--- a/tests/jet-serum.spec.ts
+++ b/tests/jet-serum.spec.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@project-serum/anchor";
 import { Market as SerumMarket } from "@project-serum/serum";
 import {
+  Connection,
   Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
@@ -24,8 +25,7 @@ import BN from "bn.js";
 import { u64 } from "@solana/spl-token";
 import * as util from "util";
 import { initTransactionLogs } from "app/src/scripts/jet";
-import { expect } from "chai";
-
+import { assert, expect } from "chai";
 
 const TEST_CURRENCY = "LTD";
 
@@ -244,7 +244,7 @@ describe("jet-serum", () => {
         liquidationPremium: 100,
         manageFeeRate: 50,
         manageFeeCollectionThreshold: new BN(10),
-        loanOriginationFee: 10,
+        loanOriginationFee: 0,
         liquidationSlippage: 300,
         liquidationDexTradeMax: new BN(1000 * LAMPORTS_PER_SOL),
         confidenceThreshold: 500,
@@ -338,8 +338,8 @@ describe("jet-serum", () => {
     );
     await placeMarketOrders(
       wsol,
-      MarketMaker.makeOrders([[19.5, 100]]),
-      MarketMaker.makeOrders([[21.5, 100]])
+      MarketMaker.makeOrders([[84.95, 100]]),
+      MarketMaker.makeOrders([[85.15, 100]])
     );
     await placeMarketOrders(
       wbtc,
@@ -351,6 +351,8 @@ describe("jet-serum", () => {
       MarketMaker.makeOrders([[200.08, 100]]),
       MarketMaker.makeOrders([[199.04, 100]])
     );
+
+    await jetMarket.refresh();
   });
 
   it("user deposits", async () => {
@@ -426,7 +428,7 @@ describe("jet-serum", () => {
     ]);
   });
 
-  it("allow basic dex liquidation", async () => {
+  it("allow basic dex sell liquidation", async () => {
     await utils.pyth.updatePriceAccount(wbtc.pythPrice, {
       exponent: -9,
       aggregatePriceInfo: {
@@ -434,7 +436,77 @@ describe("jet-serum", () => {
       },
     });
 
+    await users[3].client.refresh();
+    let collateralBalance = users[3].client
+      .collateral()
+      .find(
+        (a) => a.mint.toBase58() == wbtc.reserve.data.depositNoteMint.toBase58()
+      ).amount;
+    let loanBalance = users[3].client
+      .loans()
+      .find(
+        (a) => a.mint.toBase58() == usdc.reserve.data.loanNoteMint.toBase58()
+      ).amount;
+    assert.equal(collateralBalance.toString(), wbtc.token.amount(1).toString());
+    assert.equal(loanBalance.toString(), usdc.token.amount(870).toString());
+
     await users[3].client.liquidateDex(usdc.reserve, wbtc.reserve);
+
+    await users[3].client.refresh();
+    collateralBalance = users[3].client
+      .collateral()
+      .find(
+        (a) => a.mint.toBase58() == wbtc.reserve.data.depositNoteMint.toBase58()
+      ).amount;
+    loanBalance = users[3].client
+      .loans()
+      .find(
+        (a) => a.mint.toBase58() == usdc.reserve.data.loanNoteMint.toBase58()
+      ).amount;
+    expect(collateralBalance.toNumber()).to.be.closeTo(631578948, 1);
+    expect(loanBalance.toNumber()).to.be.closeTo(505226681, 1);
+  });
+
+  it("allow basic dex buy liquidation", async () => {
+    await utils.pyth.updatePriceAccount(wsol.pythPrice, {
+      exponent: -9,
+      aggregatePriceInfo: {
+        price: 85n * 1000000000n,
+      },
+    });
+
+    await users[0].client.refresh();
+    let collateralBalance = users[0].client
+      .collateral()
+      .find(
+        (a) => a.mint.toBase58() == usdc.reserve.data.depositNoteMint.toBase58()
+      ).amount;
+    let loanBalance = users[0].client
+      .loans()
+      .find(
+        (a) => a.mint.toBase58() == wsol.reserve.data.loanNoteMint.toBase58()
+      ).amount;
+    assert.equal(
+      collateralBalance.toString(),
+      usdc.token.amount(1000).toString()
+    );
+    assert.equal(loanBalance.toString(), "10010000000".toString());
+
+    await users[0].client.liquidateDex(wsol.reserve, usdc.reserve);
+
+    await users[0].client.refresh();
+    collateralBalance = users[0].client
+      .collateral()
+      .find(
+        (a) => a.mint.toBase58() == usdc.reserve.data.depositNoteMint.toBase58()
+      ).amount;
+    loanBalance = users[0].client
+      .loans()
+      .find(
+        (a) => a.mint.toBase58() == wsol.reserve.data.loanNoteMint.toBase58()
+      ).amount;
+    expect(collateralBalance.toNumber()).to.be.closeTo(732368421, 1);
+    expect(loanBalance.toNumber()).to.be.closeTo(6892567506, 1);
   });
 
   it("dex liquidation with 10 collaterals", async () => {
@@ -521,10 +593,10 @@ describe("jet-serum", () => {
       ].flat()
     );
 
-    await Promise.all(assets.map((asset) => asset.reserve.refresh()));
+    await Promise.all(assets.map((asset) => asset.reserve.sendRefreshTx()));
     await Promise.all(
       [
-        assets.map((asset) => asset.reserve.refresh()),
+        assets.map((asset) => asset.reserve.sendRefreshTx()),
         user.client.borrow(
           usdc.reserve,
           lenderTokenAccount,
@@ -544,12 +616,12 @@ describe("jet-serum", () => {
       )
     );
 
-    await Promise.all(assets.map((asset) => asset.reserve.refresh()));
+    await Promise.all(assets.map((asset) => asset.reserve.sendRefreshTx()));
     await Promise.all(
       [
         user.client.liquidateDex(usdc.reserve, assets[0].reserve),
         user.client.liquidateDex(usdc.reserve, assets[1].reserve),
-        assets.map((asset) => asset.reserve.refresh()),
+        assets.map((asset) => asset.reserve.sendRefreshTx()),
       ].flat()
     );
   });

--- a/tests/jet-serum.spec.ts
+++ b/tests/jet-serum.spec.ts
@@ -463,8 +463,8 @@ describe("jet-serum", () => {
       .find(
         (a) => a.mint.toBase58() == usdc.reserve.data.loanNoteMint.toBase58()
       ).amount;
-    expect(collateralBalance.toNumber()).to.be.closeTo(631578948, 1);
-    expect(loanBalance.toNumber()).to.be.closeTo(505226681, 1);
+    expect(collateralBalance.toNumber()).to.be.closeTo(631578940, 10);
+    expect(loanBalance.toNumber()).to.be.closeTo(505226680, 10);
   });
 
   it("allow basic dex buy liquidation", async () => {
@@ -505,8 +505,8 @@ describe("jet-serum", () => {
       .find(
         (a) => a.mint.toBase58() == wsol.reserve.data.loanNoteMint.toBase58()
       ).amount;
-    expect(collateralBalance.toNumber()).to.be.closeTo(732368421, 1);
-    expect(loanBalance.toNumber()).to.be.closeTo(6892567506, 1);
+    expect(collateralBalance.toNumber()).to.be.closeTo(732368420, 10);
+    expect(loanBalance.toNumber()).to.be.closeTo(6892567500, 10);
   });
 
   it("dex liquidation with 10 collaterals", async () => {

--- a/tests/jet.spec.ts
+++ b/tests/jet.spec.ts
@@ -362,7 +362,7 @@ describe("jet", async () => {
   it("halts borrows", async () => {
     await jetMarket.setFlags(new splToken.u64(MarketFlags.HaltBorrows));
 
-    await wsol.reserve.refresh();
+    await wsol.reserve.sendRefreshTx();
     await expect(
       userB.client.borrow(
         usdc.reserve,
@@ -441,7 +441,7 @@ describe("jet", async () => {
     ).address;
 
     await jetMarket.refresh();
-    await wsol.reserve.refresh();
+    await wsol.reserve.sendRefreshTx();
     const txId = await user.client.borrow(
       asset.reserve,
       tokenAccountKey,
@@ -476,7 +476,7 @@ describe("jet", async () => {
     const amount = Amount.tokens(usdcDeposit * 0.1001);
     const tokenAccount = user.tokenAccounts[usdc.token.publicKey.toBase58()];
 
-    await wsol.reserve.refresh();
+    await wsol.reserve.sendRefreshTx();
 
     const tx = await user.client.makeBorrowTx(
       usdc.reserve,
@@ -499,7 +499,7 @@ describe("jet", async () => {
     // Give it some seconds for interest to accrue
     await new Promise((r) => setTimeout(r, 2000));
 
-    await usdc.reserve.refresh();
+    await usdc.reserve.sendRefreshTx();
 
     const tx = await user.client.makeWithdrawCollateralTx(wsol.reserve, amount);
     let result = await client.program.provider.simulate(tx, [user.wallet]);
@@ -516,7 +516,7 @@ describe("jet", async () => {
     const amount = Amount.tokens(wsolWithdrawal);
     const tokenAccountKey = user.tokenAccounts[wsol.token.publicKey.toBase58()];
 
-    await usdc.reserve.refresh();
+    await usdc.reserve.sendRefreshTx();
 
     await user.client.withdrawCollateral(wsol.reserve, amount);
     await user.client.withdraw(wsol.reserve, tokenAccountKey, amount);
@@ -567,14 +567,14 @@ describe("jet", async () => {
   it("interest accrues", async () => {
     const asset = usdc;
 
-    await asset.reserve.refresh();
+    await asset.reserve.sendRefreshTx();
     let _reserve = await loadReserve(asset.reserve.address);
     const _debt0 = _reserve.state.outstandingDebt;
     const t0 = _reserve.state.accruedUntil;
 
     await new Promise((r) => setTimeout(r, 2000));
 
-    await asset.reserve.refresh();
+    await asset.reserve.sendRefreshTx();
     _reserve = await loadReserve(asset.reserve.address);
     const debt1 = _reserve.state.outstandingDebt;
     const t1 = _reserve.state.accruedUntil;
@@ -644,7 +644,7 @@ describe("jet", async () => {
     const amount = Amount.depositNotes(usdcDeposit * 0.2);
     const tokenAccountKey = user.tokenAccounts[usdc.token.publicKey.toBase58()];
 
-    await wsol.reserve.refresh();
+    await wsol.reserve.sendRefreshTx();
 
     await user.client.withdrawCollateral(usdc.reserve, amount);
     await user.client.withdraw(usdc.reserve, tokenAccountKey, amount);
@@ -722,7 +722,7 @@ describe("jet", async () => {
     const amount = Amount.tokens(wsolDeposit * 0.95);
     const tokenAccountKey = user.tokenAccounts[wsol.token.publicKey.toBase58()];
 
-    await usdc.reserve.refresh();
+    await usdc.reserve.sendRefreshTx();
 
     await user.client.withdrawCollateral(wsol.reserve, amount);
     await user.client.withdraw(wsol.reserve, tokenAccountKey, amount);
@@ -767,7 +767,7 @@ describe("jet", async () => {
     const amount = Amount.depositNotes(usdcDeposit * 0.8);
     const tokenAccountKey = user.tokenAccounts[usdc.token.publicKey.toBase58()];
 
-    await wsol.reserve.refresh();
+    await wsol.reserve.sendRefreshTx();
 
     await user.client.withdrawCollateral(usdc.reserve, amount);
     await user.client.withdraw(usdc.reserve, tokenAccountKey, amount);

--- a/tests/jet.spec.ts
+++ b/tests/jet.spec.ts
@@ -865,7 +865,6 @@ describe("jet", async () => {
         manageFeeRate: config.manageFeeRate,
         manageFeeCollectionThreshold: config.manageFeeCollectionThreshold,
         loanOriginationFee: config.loanOriginationFee,
-        liquidationSlippage: config.liquidationSlippage,
         liquidationDexTradeMax: new BN(config.liquidationDexTradeMax),
         confidenceThreshold: config.confidenceThreshold,
       } as ReserveConfig;


### PR DESCRIPTION
Rework the calculations in the serum liquidation to find the worst acceptable price to set when placing a limit order. This allows for better efficiency by accepting trades with partial order fills.

This also now allows for serum liquidations to occur when the quote token is being used as collateral.