### PR TITLE
JET-199: Add fn to retrieve latest Pyth price

### DIFF
--- a/tests/jet-utils.spec.ts
+++ b/tests/jet-utils.spec.ts
@@ -1,0 +1,66 @@
+import * as anchor from "@project-serum/anchor";
+import {
+  PublicKey,
+} from "@solana/web3.js";
+
+import { TestUtils } from "./utils";
+import { Price as PythPrice, Product as PythProduct } from "./utils/pyth";
+import { assert } from "chai";
+
+describe("jet-utils", () => {
+  let IDL: anchor.Idl;
+  const program: anchor.Program = anchor.workspace.Jet;
+  const provider = anchor.Provider.local();
+  const wallet = provider.wallet as anchor.Wallet;
+
+  const utils = new TestUtils(provider.connection, wallet);
+  
+  it("should roundtrip Pyth prices", async () => {
+    const pricePublisher = await PublicKey.createWithSeed(wallet.publicKey, 'price-publisher', program.programId);
+    const nextPriceAccount = await PublicKey.createWithSeed(wallet.publicKey, 'next-price', program.programId);
+    const productAccount = await PublicKey.createWithSeed(wallet.publicKey, 'product-account', program.programId);
+
+    const pythPrice = await utils.pyth.createPriceAccount();
+    const expectedPrice: PythPrice = {
+      exponent: -9,
+      aggregatePriceInfo: {
+        price: 12n * 1000000000n,
+        conf: 0n,
+        status: 'trading',
+        pubSlot: 111n,
+      },
+      priceType: 'price',
+      version: 3,
+      size: 3312,
+      type: 1,
+      validSlot: 554n,
+      currentSlot: 12345n,
+      aggregatePriceUpdaterAccountKey: PublicKey.default,
+      nextPriceAccountKey: nextPriceAccount,
+      productAccountKey: productAccount,
+      priceComponents: [{
+        agg: {
+          price: 13n * 1000000000n,
+          conf: 0n,
+          status: 'trading',
+          pubSlot: 1n,
+        },
+        latest: {
+          price: 11n * 1000000000n,
+          // This fails if the conf is not set
+          conf: 1n,
+          status: 'trading',
+          pubSlot: 1n,
+        },
+        publisher: pricePublisher
+      }]
+    };
+    await utils.pyth.updatePriceAccount(pythPrice, expectedPrice);
+
+    // Get the account's price
+    const price = await utils.pyth.getPriceAccountData(pythPrice);
+
+    // The price retrieved should equal the price saved
+    assert.deepEqual(price, expectedPrice);
+  });
+});

--- a/tests/utils/data.ts
+++ b/tests/utils/data.ts
@@ -83,4 +83,12 @@ export class DataManager {
             this.wallet.payer,
         ]);
     }
+
+    /**
+     * Retrieve the data stored in an account
+     * @param account The keypair for the account to retrieve
+     */
+    async retrieve(account: Keypair): Promise<web3.AccountInfo<Buffer>> {
+        return await this.conn.getAccountInfo(account.publicKey)
+    }
 }

--- a/tests/utils/pyth.ts
+++ b/tests/utils/pyth.ts
@@ -162,7 +162,6 @@ function readPriceBuffer(buf: Buffer, offset: number): Price | null {
     return price
 }
 
-// FIXME: test that this works
 function readPublicKeyBuffer(buf: Buffer, start: number): PublicKey {
     let string = buf.toString("binary", start, start + 32);
     let key = new PublicKey(Buffer.from(string, 'binary'));
@@ -221,8 +220,7 @@ function readPriceComponentBuffer(
     offset: number,
 ): PriceComponent {
     return {
-        // FIXME: is this right?
-        publisher: new PublicKey(buf.slice(offset, 32)),
+        publisher: new PublicKey(buf.slice(offset, offset + 32)),
         agg: readPriceInfoBuffer(buf, offset + 32),
         latest: readPriceInfoBuffer(buf, offset + 64)
     }


### PR DESCRIPTION
Adds some helper functions to retrieve Pyth prices for unit tests. Note that this is a sub-task of JET-198