### PR TITLE
JET-269 Fix amount owed not updating after repay

### DIFF
--- a/app/src/components/TradePanel.svelte
+++ b/app/src/components/TradePanel.svelte
@@ -21,9 +21,9 @@
   const adjustInterface = () => {
     inputError = ''
     inputAmount = null;
-    checkDisabledInput();
     getMaxInput();
     adjustCollateralizationRatio();
+    checkDisabledInput();
   };
 
   // Check if user input should be disabled


### PR DESCRIPTION
Not sure why this works, could be that by getting maximum input AFTER disabling our trade panel, the disable doesn't actually update to reflect that the user doesn't owe anything anymore. But I tested extensively and this fix works.