### PR TITLE
Unable to withdraw to 125% c-ratio

### DIFF
--- a/app/src/components/TradePanel.svelte
+++ b/app/src/components/TradePanel.svelte
@@ -176,7 +176,7 @@
       } else if (tradeAmount.uiAmountFloat > $USER.collateralBalances[$MARKET.currentReserve.abbrev]) {
         inputError = dictionary[$USER.language].cockpit.lessFunds;
       // User is below the minimum c-ratio
-      } else if ($USER.position.borrowedValue && $USER.position.colRatio <= $MARKET.minColRatio) {
+      } else if ($USER.position.borrowedValue && $USER.position.colRatio <= $MARKET.programMinColRatio) {
         inputError = dictionary[$USER.language].cockpit.belowMinCRatio;
       // Otherwise, send withdraw
       } else {

--- a/app/src/scripts/subscribe.ts
+++ b/app/src/scripts/subscribe.ts
@@ -187,11 +187,16 @@ export const subscribeToAssets = async () => {
   promise = getAccountInfoAndSubscribe(connection, user.wallet.publicKey, account => {
     USER.update(user => {
       if (user.assets) {
+        const reserve = market.reserves["SOL"];
+
         // Need to be careful constructing a BN from a number.
         // If the user has more than 2^53 lamports it will throw for not having enough precision.
-        user.assets.sol = new TokenAmount(new BN(account?.lamports.toString() ?? "0"), SOL_DECIMALS);
-        // Update wallet SOL balance
-        user.walletBalances.SOL = user.assets.sol.uiAmountFloat;
+        user.assets.tokens.SOL.walletTokenBalance = new TokenAmount(new BN(account?.lamports.toString() ?? 0), SOL_DECIMALS)
+
+        user.assets.sol = user.assets.tokens.SOL.walletTokenBalance
+        user.walletBalances.SOL = user.assets.tokens.SOL.walletTokenBalance.uiAmountFloat;
+        
+        deriveValues(reserve, user.assets.tokens.SOL);
       }
       return user;
     });


### PR DESCRIPTION
This PR fixes 2 bugs

Users would not be able to withdraw down to 125% if there c-ratio was _currently_ < 130%

A change to the users SOL wallet balance would not invoke `deriveValues`