### PR TITLE
JET-323: allow free movement for deposit notes

### DIFF
--- a/programs/jet/src/instructions/deposit_tokens.rs
+++ b/programs/jet/src/instructions/deposit_tokens.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Copyright (C) 2021 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, MintTo, Transfer};
+
+use crate::state::*;
+use crate::{Amount, Rounding};
+
+#[derive(Accounts)]
+pub struct DepositTokens<'info> {
+    /// The relevant market this deposit is for
+    #[account(has_one = market_authority)]
+    pub market: Loader<'info, Market>,
+
+    /// The market's authority account
+    pub market_authority: AccountInfo<'info>,
+
+    /// The reserve being deposited into
+    #[account(mut,
+              has_one = market,
+              has_one = vault,
+              has_one = deposit_note_mint)]
+    pub reserve: Loader<'info, Reserve>,
+
+    /// The reserve's vault where the deposited tokens will be transferred to
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+
+    /// The mint for the deposit notes
+    #[account(mut)]
+    pub deposit_note_mint: AccountInfo<'info>,
+
+    /// The user/authority that owns the deposit
+    #[account(signer)]
+    pub depositor: AccountInfo<'info>,
+
+    /// The token account to receive the deposit notes
+    #[account(mut)]
+    pub deposit_note_account: AccountInfo<'info>,
+
+    /// The token account with the tokens to be deposited
+    #[account(mut)]
+    pub deposit_source: AccountInfo<'info>,
+
+    #[account(address = token::ID)]
+    pub token_program: AccountInfo<'info>,
+}
+
+impl<'info> DepositTokens<'info> {
+    fn transfer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        CpiContext::new(
+            self.token_program.clone(),
+            Transfer {
+                from: self.deposit_source.to_account_info(),
+                to: self.vault.to_account_info(),
+                authority: self.depositor.clone(),
+            },
+        )
+    }
+
+    fn note_mint_context(&self) -> CpiContext<'_, '_, '_, 'info, MintTo<'info>> {
+        CpiContext::new(
+            self.token_program.clone(),
+            MintTo {
+                to: self.deposit_note_account.to_account_info(),
+                mint: self.deposit_note_mint.to_account_info(),
+                authority: self.market_authority.clone(),
+            },
+        )
+    }
+}
+
+/// Deposit tokens into a reserve
+pub fn handler(ctx: Context<DepositTokens>, amount: Amount) -> ProgramResult {
+    let market = ctx.accounts.market.load()?;
+    let mut reserve = ctx.accounts.reserve.load_mut()?;
+    let clock = Clock::get()?;
+    let reserve_info = market.reserves().get_cached(reserve.index, clock.slot);
+
+    market.verify_ability_deposit_withdraw()?;
+
+    // Calculate the number of new notes that need to be minted to represent
+    // the current value being deposited
+    let token_amount = amount.as_tokens(reserve_info, Rounding::Up);
+    let note_amount = amount.as_deposit_notes(reserve_info, Rounding::Down)?;
+
+    reserve.deposit(token_amount, note_amount);
+
+    // Now that we have the note value, we can transfer this deposit
+    // to the vault and mint the new notes
+    token::transfer(ctx.accounts.transfer_context(), token_amount)?;
+
+    token::mint_to(
+        ctx.accounts
+            .note_mint_context()
+            .with_signer(&[&market.authority_seeds()]),
+        note_amount,
+    )?;
+
+    Ok(())
+}

--- a/programs/jet/src/instructions/mod.rs
+++ b/programs/jet/src/instructions/mod.rs
@@ -30,6 +30,7 @@ pub mod close_deposit_account;
 pub mod borrow;
 pub mod deposit;
 pub mod deposit_collateral;
+pub mod deposit_tokens;
 pub mod liquidate;
 pub mod liquidate_dex;
 pub mod refresh_reserve;
@@ -37,6 +38,7 @@ pub mod repay;
 pub mod update_reserve_config;
 pub mod withdraw;
 pub mod withdraw_collateral;
+pub mod withdraw_tokens;
 
 pub use borrow::*;
 pub use close_deposit_account::*;

--- a/programs/jet/src/instructions/withdraw.rs
+++ b/programs/jet/src/instructions/withdraw.rs
@@ -17,10 +17,10 @@
 
 use anchor_lang::prelude::*;
 use anchor_lang::Key;
-use anchor_spl::token::{self, Burn, Transfer};
+use anchor_spl::token;
 
 use crate::state::*;
-use crate::{Amount, Rounding};
+use crate::Amount;
 
 #[derive(Accounts)]
 #[instruction(bump: u8)]
@@ -69,59 +69,18 @@ pub struct Withdraw<'info> {
     pub token_program: AccountInfo<'info>,
 }
 
-impl<'info> Withdraw<'info> {
-    fn transfer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
-        CpiContext::new(
-            self.token_program.clone(),
-            Transfer {
-                from: self.vault.to_account_info(),
-                to: self.withdraw_account.to_account_info(),
-                authority: self.market_authority.clone(),
-            },
-        )
-    }
-
-    fn note_burn_context(&self) -> CpiContext<'_, '_, '_, 'info, Burn<'info>> {
-        CpiContext::new(
-            self.token_program.clone(),
-            Burn {
-                to: self.deposit_account.to_account_info(),
-                mint: self.deposit_note_mint.to_account_info(),
-                authority: self.market_authority.clone(),
-            },
-        )
-    }
-}
-
 /// Withdraw tokens from a reserve
 pub fn handler(ctx: Context<Withdraw>, _bump: u8, amount: Amount) -> ProgramResult {
-    let market = ctx.accounts.market.load()?;
-    let mut reserve = ctx.accounts.reserve.load_mut()?;
-    let clock = Clock::get().unwrap();
-    let reserve_info = market.reserves().get_cached(reserve.index, clock.slot);
-
-    market.verify_ability_deposit_withdraw()?;
-
-    // Calculate the number of tokens that the request amount is worth
-    let token_amount = amount.as_tokens(reserve_info, Rounding::Down);
-    let note_amount = amount.as_deposit_notes(reserve_info, Rounding::Up)?;
-
-    reserve.withdraw(token_amount, note_amount);
-
-    // Transfer the tokens from the reserve, and burn the deposit notes
-    token::transfer(
-        ctx.accounts
-            .transfer_context()
-            .with_signer(&[&market.authority_seeds()]),
-        token_amount,
-    )?;
-
-    token::burn(
-        ctx.accounts
-            .note_burn_context()
-            .with_signer(&[&market.authority_seeds()]),
-        note_amount,
-    )?;
-
-    Ok(())
+    super::withdraw_tokens::handler(
+        Context::new(
+            ctx.program_id,
+            &mut super::withdraw_tokens::WithdrawTokens::try_accounts(
+                ctx.program_id,
+                &mut &*ctx.accounts.to_account_infos(),
+                &[],
+            )?,
+            &[],
+        ),
+        amount,
+    )
 }

--- a/programs/jet/src/instructions/withdraw_tokens.rs
+++ b/programs/jet/src/instructions/withdraw_tokens.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Copyright (C) 2021 JET PROTOCOL HOLDINGS, LLC.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Burn, Transfer};
+
+use crate::state::*;
+use crate::{Amount, Rounding};
+
+#[derive(Accounts)]
+pub struct WithdrawTokens<'info> {
+    /// The relevant market this withdraw is for
+    #[account(has_one = market_authority)]
+    pub market: Loader<'info, Market>,
+
+    /// The market's authority account
+    pub market_authority: AccountInfo<'info>,
+
+    /// The reserve being withdrawn from
+    #[account(mut,
+              has_one = market,
+              has_one = vault,
+              has_one = deposit_note_mint)]
+    pub reserve: Loader<'info, Reserve>,
+
+    /// The reserve's vault where the withdrawn tokens will be transferred from
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+
+    /// The mint for the deposit notes
+    #[account(mut)]
+    pub deposit_note_mint: AccountInfo<'info>,
+
+    /// The user/authority that owns the deposit
+    #[account(signer)]
+    pub depositor: AccountInfo<'info>,
+
+    /// The account that stores the deposit notes
+    #[account(mut)]
+    pub deposit_note_account: AccountInfo<'info>,
+
+    /// The token account where to transfer withdrawn tokens to
+    #[account(mut)]
+    pub withdraw_account: AccountInfo<'info>,
+
+    #[account(address = token::ID)]
+    pub token_program: AccountInfo<'info>,
+}
+
+impl<'info> WithdrawTokens<'info> {
+    fn transfer_context(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
+        CpiContext::new(
+            self.token_program.clone(),
+            Transfer {
+                from: self.vault.to_account_info(),
+                to: self.withdraw_account.to_account_info(),
+                authority: self.market_authority.clone(),
+            },
+        )
+    }
+
+    fn note_burn_context(&self) -> CpiContext<'_, '_, '_, 'info, Burn<'info>> {
+        CpiContext::new(
+            self.token_program.clone(),
+            Burn {
+                to: self.deposit_note_account.to_account_info(),
+                mint: self.deposit_note_mint.to_account_info(),
+                authority: self.market_authority.clone(),
+            },
+        )
+    }
+}
+
+/// Withdraw tokens from a reserve
+pub fn handler(ctx: Context<WithdrawTokens>, amount: Amount) -> ProgramResult {
+    let market = ctx.accounts.market.load()?;
+    let mut reserve = ctx.accounts.reserve.load_mut()?;
+    let clock = Clock::get().unwrap();
+    let reserve_info = market.reserves().get_cached(reserve.index, clock.slot);
+
+    market.verify_ability_deposit_withdraw()?;
+
+    // Calculate the number of tokens that the request amount is worth
+    let token_amount = amount.as_tokens(reserve_info, Rounding::Down);
+    let note_amount = amount.as_deposit_notes(reserve_info, Rounding::Up)?;
+
+    reserve.withdraw(token_amount, note_amount);
+
+    // Transfer the tokens from the reserve, and burn the deposit notes
+    token::transfer(
+        ctx.accounts
+            .transfer_context()
+            .with_signer(&[&market.authority_seeds()]),
+        token_amount,
+    )?;
+
+    token::burn(
+        ctx.accounts
+            .note_burn_context()
+            .with_signer(&[&market.authority_seeds()]),
+        note_amount,
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
Allow users of the program to have their deposit notes transferred to
token accounts outside the program control.

Introduces two new instructions to facilitate this
  * `deposit_tokens` - like `deposit`, but destination account for notes
    can be any token account.
  * `withdraw_tokens` - like `withdraw`, but source account for notes
    can be any token account.