### PR TITLE
update the limit fraction not to overstate collateral repayment

### DIFF
--- a/programs/jet/src/instructions/liquidate_dex.rs
+++ b/programs/jet/src/instructions/liquidate_dex.rs
@@ -465,7 +465,7 @@ impl<'a, 'info> SwapCalculator<'a, 'info> {
         }
 
         let limit_fraction = (c_ratio_ltv - Number::ONE)
-            / (min_c_ratio * (Number::ONE - liquidation_fee) - Number::ONE);
+            / (min_c_ratio / (Number::ONE + liquidation_fee) - Number::ONE);
 
         let collateral_sellable_value = limit_fraction * collateral_value;
         let loan_repay_value = collateral_sellable_value / (Number::ONE + liquidation_fee);

--- a/programs/jet/src/state/obligation.rs
+++ b/programs/jet/src/state/obligation.rs
@@ -679,7 +679,7 @@ mod tests {
 
         ctx.obligation.repay(&loan, Number::from(347_826)).unwrap();
 
-        assert_eq!(765_217, collateral_returned.as_u64_rounded(0));
+        assert_eq!(733_333, collateral_returned.as_u64_rounded(0));
         assert_eq!(
             152_174,
             ctx.obligation
@@ -690,7 +690,7 @@ mod tests {
                 .as_u64_rounded(0)
         );
         assert_eq!(
-            384_783,
+            416_667,
             ctx.obligation
                 .collateral()
                 .position(&collateral)
@@ -730,7 +730,7 @@ mod tests {
             .liquidate(&ctx.market, 0, &collateral, &loan, Number::from(500_000))
             .unwrap();
 
-        assert_eq!(1_100_000, collateral_returned.as_u64_rounded(0));
+        assert_eq!(1_018_519, collateral_returned.as_u64_rounded(0));
     }
 
     #[test]

--- a/programs/jet/src/state/obligation.rs
+++ b/programs/jet/src/state/obligation.rs
@@ -214,7 +214,7 @@ impl Obligation {
         };
 
         let limit_fraction = (c_ratio_ltv - Number::ONE)
-            / (min_c_ratio * (Number::ONE - liquidation_bonus) - Number::ONE);
+            / (min_c_ratio / (Number::ONE + liquidation_bonus) - Number::ONE);
 
         let collateral_sellable_value = std::cmp::min(
             (Number::ONE + liquidation_bonus) * repaid_value,

--- a/tests/jet-serum.spec.ts
+++ b/tests/jet-serum.spec.ts
@@ -463,8 +463,8 @@ describe("jet-serum", () => {
       .find(
         (a) => a.mint.toBase58() == usdc.reserve.data.loanNoteMint.toBase58()
       ).amount;
-    expect(collateralBalance.toNumber()).to.be.closeTo(631578940, 10);
-    expect(loanBalance.toNumber()).to.be.closeTo(505226680, 10);
+    expect(collateralBalance.toNumber()).to.be.closeTo(631770833, 10);
+    expect(loanBalance.toNumber()).to.be.closeTo(505416667, 10);
   });
 
   it("allow basic dex buy liquidation", async () => {
@@ -505,8 +505,8 @@ describe("jet-serum", () => {
       .find(
         (a) => a.mint.toBase58() == wsol.reserve.data.loanNoteMint.toBase58()
       ).amount;
-    expect(collateralBalance.toNumber()).to.be.closeTo(732368420, 10);
-    expect(loanBalance.toNumber()).to.be.closeTo(6892567500, 10);
+    expect(collateralBalance.toNumber()).to.be.closeTo(732507812, 10);
+    expect(loanBalance.toNumber()).to.be.closeTo(6894191161, 10);
   });
 
   it("dex liquidation with 10 collaterals", async () => {


### PR DESCRIPTION
When we calculate the repayment tokens, we end up slightly overpaying by a small amount.

This change fixes the approximation of `limit_fraction` to be exact, leading to a c-ratio of exactly 125%.