### PR TITLE
fix `withdraw_tokens`

### DIFF
--- a/app/src/scripts/jet.ts
+++ b/app/src/scripts/jet.ts
@@ -744,6 +744,7 @@ export const withdraw = async (abbrev: string, amount: Amount)
       depositAccount: asset.depositNotePubkey,
       withdrawAccount,
 
+      jetProgram: program.programId,
       tokenProgram: TOKEN_PROGRAM_ID,
     },
   });

--- a/libraries/ts/src/user.ts
+++ b/libraries/ts/src/user.ts
@@ -8,7 +8,7 @@ import {
 } from "@solana/web3.js";
 import * as anchor from "@project-serum/anchor";
 
-import { Amount, DEX_ID, DEX_ID_DEVNET } from ".";
+import { Amount, DEX_ID, DEX_ID_DEVNET, JET_ID } from ".";
 import { DerivedAccount, JetClient } from "./client";
 import { JetMarket, JetMarketReserveInfo } from "./market";
 import {
@@ -269,6 +269,7 @@ export class JetUser implements User {
             vault: reserve.data.vault,
             depositNoteMint: reserve.data.depositNoteMint,
 
+            jetProgram: JET_ID,
             tokenProgram: TOKEN_PROGRAM_ID,
           },
         }

--- a/programs/jet/Cargo.toml
+++ b/programs/jet/Cargo.toml
@@ -13,8 +13,8 @@ doctest = false
 no-entrypoint = []
 no-idl = []
 devnet = ["anchor-spl/devnet"]
-cpi = ["no-entrypoint"]
-default = []
+cpi = []
+default = ["cpi"]
 
 [dependencies]
 anchor-lang = "0.18.2"

--- a/programs/jet/src/instructions/withdraw_tokens.rs
+++ b/programs/jet/src/instructions/withdraw_tokens.rs
@@ -79,7 +79,7 @@ impl<'info> WithdrawTokens<'info> {
             Burn {
                 to: self.deposit_note_account.to_account_info(),
                 mint: self.deposit_note_mint.to_account_info(),
-                authority: self.market_authority.clone(),
+                authority: self.depositor.clone(),
             },
         )
     }
@@ -108,12 +108,7 @@ pub fn handler(ctx: Context<WithdrawTokens>, amount: Amount) -> ProgramResult {
         token_amount,
     )?;
 
-    token::burn(
-        ctx.accounts
-            .note_burn_context()
-            .with_signer(&[&market.authority_seeds()]),
-        note_amount,
-    )?;
+    token::burn(ctx.accounts.note_burn_context(), note_amount)?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently totally broken as is, because it uses the wrong authority when burning the deposit notes. This change fixes the instruction, and by doing so introduces a breaking change for `withdraw` which now requires the program itself to be passed in as an account parameter.