### PR TITLE
Update anchor-lang dependency from cpi library

### DIFF
--- a/libraries/cpi/Cargo.toml
+++ b/libraries/cpi/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://jetprotocol.io"
 repository = "https://github.com/jet-lab/jet-v1"
 
 [dependencies]
-anchor-lang = "0.23.0"
+anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
 borsh = "0.9"
 thiserror = "1"
 


### PR DESCRIPTION
Update anchor-lang dependency library from cpi library to fetch from `https://github.com/jet-lab/anchor`